### PR TITLE
Feat/issue 177 179 panel id and target type

### DIFF
--- a/modules/Biospecimen/src/htan_biospecimen/datamodel/biospecimen.py
+++ b/modules/Biospecimen/src/htan_biospecimen/datamodel/biospecimen.py
@@ -1,5 +1,5 @@
 # Auto generated from biospecimen.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-01T18:40:25
+# Generation date: 2026-05-01T18:50:34
 # Schema: Biospecimen
 #
 # id: https://w3id.org/htan/biospecimen

--- a/modules/Biospecimen/src/htan_biospecimen/datamodel/biospecimen.py
+++ b/modules/Biospecimen/src/htan_biospecimen/datamodel/biospecimen.py
@@ -1,5 +1,5 @@
 # Auto generated from biospecimen.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-15T14:31:35
+# Generation date: 2026-04-29T17:34:20
 # Schema: Biospecimen
 #
 # id: https://w3id.org/htan/biospecimen

--- a/modules/Biospecimen/src/htan_biospecimen/datamodel/biospecimen.py
+++ b/modules/Biospecimen/src/htan_biospecimen/datamodel/biospecimen.py
@@ -1,5 +1,5 @@
 # Auto generated from biospecimen.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-01T16:39:42
+# Generation date: 2026-05-01T18:40:25
 # Schema: Biospecimen
 #
 # id: https://w3id.org/htan/biospecimen

--- a/modules/Biospecimen/src/htan_biospecimen/datamodel/biospecimen.py
+++ b/modules/Biospecimen/src/htan_biospecimen/datamodel/biospecimen.py
@@ -1,5 +1,5 @@
 # Auto generated from biospecimen.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-29T17:34:20
+# Generation date: 2026-04-30T16:34:53
 # Schema: Biospecimen
 #
 # id: https://w3id.org/htan/biospecimen

--- a/modules/Biospecimen/src/htan_biospecimen/datamodel/biospecimen.py
+++ b/modules/Biospecimen/src/htan_biospecimen/datamodel/biospecimen.py
@@ -1,5 +1,5 @@
 # Auto generated from biospecimen.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-30T16:46:24
+# Generation date: 2026-04-30T17:14:27
 # Schema: Biospecimen
 #
 # id: https://w3id.org/htan/biospecimen

--- a/modules/Biospecimen/src/htan_biospecimen/datamodel/biospecimen.py
+++ b/modules/Biospecimen/src/htan_biospecimen/datamodel/biospecimen.py
@@ -1,5 +1,5 @@
 # Auto generated from biospecimen.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-30T17:14:27
+# Generation date: 2026-05-01T16:23:21
 # Schema: Biospecimen
 #
 # id: https://w3id.org/htan/biospecimen

--- a/modules/Biospecimen/src/htan_biospecimen/datamodel/biospecimen.py
+++ b/modules/Biospecimen/src/htan_biospecimen/datamodel/biospecimen.py
@@ -1,5 +1,5 @@
 # Auto generated from biospecimen.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-30T16:34:53
+# Generation date: 2026-04-30T16:46:24
 # Schema: Biospecimen
 #
 # id: https://w3id.org/htan/biospecimen

--- a/modules/Biospecimen/src/htan_biospecimen/datamodel/biospecimen.py
+++ b/modules/Biospecimen/src/htan_biospecimen/datamodel/biospecimen.py
@@ -1,5 +1,5 @@
 # Auto generated from biospecimen.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-01T16:23:21
+# Generation date: 2026-05-01T16:39:42
 # Schema: Biospecimen
 #
 # id: https://w3id.org/htan/biospecimen

--- a/modules/Clinical/src/htan_clinical/datamodel/clinical.py
+++ b/modules/Clinical/src/htan_clinical/datamodel/clinical.py
@@ -1,5 +1,5 @@
 # Auto generated from clinical.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-01T16:36:50
+# Generation date: 2026-05-01T18:37:28
 # Schema: Clinical
 #
 # id: https://w3id.org/htan/clinical

--- a/modules/Clinical/src/htan_clinical/datamodel/clinical.py
+++ b/modules/Clinical/src/htan_clinical/datamodel/clinical.py
@@ -1,5 +1,5 @@
 # Auto generated from clinical.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-29T17:31:13
+# Generation date: 2026-04-30T16:31:52
 # Schema: Clinical
 #
 # id: https://w3id.org/htan/clinical

--- a/modules/Clinical/src/htan_clinical/datamodel/clinical.py
+++ b/modules/Clinical/src/htan_clinical/datamodel/clinical.py
@@ -1,5 +1,5 @@
 # Auto generated from clinical.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-01T16:20:30
+# Generation date: 2026-05-01T16:36:50
 # Schema: Clinical
 #
 # id: https://w3id.org/htan/clinical

--- a/modules/Clinical/src/htan_clinical/datamodel/clinical.py
+++ b/modules/Clinical/src/htan_clinical/datamodel/clinical.py
@@ -1,5 +1,5 @@
 # Auto generated from clinical.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-30T16:31:52
+# Generation date: 2026-04-30T16:43:28
 # Schema: Clinical
 #
 # id: https://w3id.org/htan/clinical

--- a/modules/Clinical/src/htan_clinical/datamodel/clinical.py
+++ b/modules/Clinical/src/htan_clinical/datamodel/clinical.py
@@ -1,5 +1,5 @@
 # Auto generated from clinical.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-01T18:37:28
+# Generation date: 2026-05-01T18:47:53
 # Schema: Clinical
 #
 # id: https://w3id.org/htan/clinical

--- a/modules/Clinical/src/htan_clinical/datamodel/clinical.py
+++ b/modules/Clinical/src/htan_clinical/datamodel/clinical.py
@@ -1,5 +1,5 @@
 # Auto generated from clinical.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-30T16:43:28
+# Generation date: 2026-04-30T17:11:29
 # Schema: Clinical
 #
 # id: https://w3id.org/htan/clinical

--- a/modules/Clinical/src/htan_clinical/datamodel/clinical.py
+++ b/modules/Clinical/src/htan_clinical/datamodel/clinical.py
@@ -1,5 +1,5 @@
 # Auto generated from clinical.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-15T14:28:41
+# Generation date: 2026-04-29T17:31:13
 # Schema: Clinical
 #
 # id: https://w3id.org/htan/clinical

--- a/modules/Clinical/src/htan_clinical/datamodel/clinical.py
+++ b/modules/Clinical/src/htan_clinical/datamodel/clinical.py
@@ -1,5 +1,5 @@
 # Auto generated from clinical.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-30T17:11:29
+# Generation date: 2026-05-01T16:20:30
 # Schema: Clinical
 #
 # id: https://w3id.org/htan/clinical

--- a/modules/DigitalPathology/src/htan_digitalpathology/datamodel/digital_pathology.py
+++ b/modules/DigitalPathology/src/htan_digitalpathology/datamodel/digital_pathology.py
@@ -1,5 +1,5 @@
 # Auto generated from digital_pathology.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-29T17:34:41
+# Generation date: 2026-04-30T16:35:12
 # Schema: DigitalPathology
 #
 # id: https://w3id.org/htan/digital_pathology

--- a/modules/DigitalPathology/src/htan_digitalpathology/datamodel/digital_pathology.py
+++ b/modules/DigitalPathology/src/htan_digitalpathology/datamodel/digital_pathology.py
@@ -1,5 +1,5 @@
 # Auto generated from digital_pathology.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-30T17:14:46
+# Generation date: 2026-05-01T16:23:40
 # Schema: DigitalPathology
 #
 # id: https://w3id.org/htan/digital_pathology

--- a/modules/DigitalPathology/src/htan_digitalpathology/datamodel/digital_pathology.py
+++ b/modules/DigitalPathology/src/htan_digitalpathology/datamodel/digital_pathology.py
@@ -1,5 +1,5 @@
 # Auto generated from digital_pathology.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-30T16:35:12
+# Generation date: 2026-04-30T16:46:43
 # Schema: DigitalPathology
 #
 # id: https://w3id.org/htan/digital_pathology

--- a/modules/DigitalPathology/src/htan_digitalpathology/datamodel/digital_pathology.py
+++ b/modules/DigitalPathology/src/htan_digitalpathology/datamodel/digital_pathology.py
@@ -1,5 +1,5 @@
 # Auto generated from digital_pathology.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-15T14:31:54
+# Generation date: 2026-04-29T17:34:41
 # Schema: DigitalPathology
 #
 # id: https://w3id.org/htan/digital_pathology

--- a/modules/DigitalPathology/src/htan_digitalpathology/datamodel/digital_pathology.py
+++ b/modules/DigitalPathology/src/htan_digitalpathology/datamodel/digital_pathology.py
@@ -1,5 +1,5 @@
 # Auto generated from digital_pathology.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-01T16:23:40
+# Generation date: 2026-05-01T16:40:01
 # Schema: DigitalPathology
 #
 # id: https://w3id.org/htan/digital_pathology

--- a/modules/DigitalPathology/src/htan_digitalpathology/datamodel/digital_pathology.py
+++ b/modules/DigitalPathology/src/htan_digitalpathology/datamodel/digital_pathology.py
@@ -1,5 +1,5 @@
 # Auto generated from digital_pathology.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-01T16:40:01
+# Generation date: 2026-05-01T18:40:45
 # Schema: DigitalPathology
 #
 # id: https://w3id.org/htan/digital_pathology

--- a/modules/DigitalPathology/src/htan_digitalpathology/datamodel/digital_pathology.py
+++ b/modules/DigitalPathology/src/htan_digitalpathology/datamodel/digital_pathology.py
@@ -1,5 +1,5 @@
 # Auto generated from digital_pathology.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-30T16:46:43
+# Generation date: 2026-04-30T17:14:46
 # Schema: DigitalPathology
 #
 # id: https://w3id.org/htan/digital_pathology

--- a/modules/DigitalPathology/src/htan_digitalpathology/datamodel/digital_pathology.py
+++ b/modules/DigitalPathology/src/htan_digitalpathology/datamodel/digital_pathology.py
@@ -1,5 +1,5 @@
 # Auto generated from digital_pathology.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-01T18:40:45
+# Generation date: 2026-05-01T18:50:53
 # Schema: DigitalPathology
 #
 # id: https://w3id.org/htan/digital_pathology

--- a/modules/Imaging/src/htan_imaging/datamodel/imaging.py
+++ b/modules/Imaging/src/htan_imaging/datamodel/imaging.py
@@ -1,5 +1,5 @@
 # Auto generated from imaging.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-30T16:35:09
+# Generation date: 2026-04-30T16:46:40
 # Schema: Imaging
 #
 # id: https://w3id.org/htan/imaging

--- a/modules/Imaging/src/htan_imaging/datamodel/imaging.py
+++ b/modules/Imaging/src/htan_imaging/datamodel/imaging.py
@@ -1,5 +1,5 @@
 # Auto generated from imaging.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-15T14:31:51
+# Generation date: 2026-04-29T17:34:37
 # Schema: Imaging
 #
 # id: https://w3id.org/htan/imaging

--- a/modules/Imaging/src/htan_imaging/datamodel/imaging.py
+++ b/modules/Imaging/src/htan_imaging/datamodel/imaging.py
@@ -1,5 +1,5 @@
 # Auto generated from imaging.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-01T16:39:58
+# Generation date: 2026-05-01T18:40:41
 # Schema: Imaging
 #
 # id: https://w3id.org/htan/imaging

--- a/modules/Imaging/src/htan_imaging/datamodel/imaging.py
+++ b/modules/Imaging/src/htan_imaging/datamodel/imaging.py
@@ -1,5 +1,5 @@
 # Auto generated from imaging.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-01T16:23:37
+# Generation date: 2026-05-01T16:39:58
 # Schema: Imaging
 #
 # id: https://w3id.org/htan/imaging

--- a/modules/Imaging/src/htan_imaging/datamodel/imaging.py
+++ b/modules/Imaging/src/htan_imaging/datamodel/imaging.py
@@ -1,5 +1,5 @@
 # Auto generated from imaging.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-30T17:14:43
+# Generation date: 2026-05-01T16:23:37
 # Schema: Imaging
 #
 # id: https://w3id.org/htan/imaging

--- a/modules/Imaging/src/htan_imaging/datamodel/imaging.py
+++ b/modules/Imaging/src/htan_imaging/datamodel/imaging.py
@@ -1,5 +1,5 @@
 # Auto generated from imaging.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-01T18:40:41
+# Generation date: 2026-05-01T18:50:50
 # Schema: Imaging
 #
 # id: https://w3id.org/htan/imaging

--- a/modules/Imaging/src/htan_imaging/datamodel/imaging.py
+++ b/modules/Imaging/src/htan_imaging/datamodel/imaging.py
@@ -1,5 +1,5 @@
 # Auto generated from imaging.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-30T16:46:40
+# Generation date: 2026-04-30T17:14:43
 # Schema: Imaging
 #
 # id: https://w3id.org/htan/imaging

--- a/modules/Imaging/src/htan_imaging/datamodel/imaging.py
+++ b/modules/Imaging/src/htan_imaging/datamodel/imaging.py
@@ -1,5 +1,5 @@
 # Auto generated from imaging.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-29T17:34:37
+# Generation date: 2026-04-30T16:35:09
 # Schema: Imaging
 #
 # id: https://w3id.org/htan/imaging

--- a/modules/MultiplexMicroscopy/domains/level_2.yaml
+++ b/modules/MultiplexMicroscopy/domains/level_2.yaml
@@ -148,12 +148,6 @@ classes:
         description: Unique HTAN identifier for the antibody/reagent panel used to acquire this image. Must match the HTAN_PANEL_ID in the corresponding ChannelMetadata RecordSet. Follows the HTAN identifier format with a P-prefix segment (e.g., HTA201_1_P1).
         pattern: "^(?=.{1,50}$)(HTA2[0-2][0-9])_(0000|EXT[0-9]{1,18}|[0-9]{1,21})_(P[0-9]{1,20})$"
 
-      CHANNEL_METADATA_ID:
-        range: string
-        required: true
-        title: "Channel Metadata ID"
-        description: Unique identifier specifying the location of the required channel metadata (Synapse ID)
-        pattern: "^syn\\d+$"
     rules:
       - preconditions:
           slot_conditions:

--- a/modules/MultiplexMicroscopy/domains/level_2.yaml
+++ b/modules/MultiplexMicroscopy/domains/level_2.yaml
@@ -1,6 +1,5 @@
 name: MultiplexMicroscopyLevel2
 id: https://w3id.org/htan/multiplex_microscopy/level_2
-version: "1.1.0"
 description: HTAN Multiplex Microscopy Level 2 - Imaging data with channel metadata
 
 imports:

--- a/modules/MultiplexMicroscopy/domains/level_2.yaml
+++ b/modules/MultiplexMicroscopy/domains/level_2.yaml
@@ -1,5 +1,6 @@
 name: MultiplexMicroscopyLevel2
 id: https://w3id.org/htan/multiplex_microscopy/level_2
+version: "1.1.0"
 description: HTAN Multiplex Microscopy Level 2 - Imaging data with channel metadata
 
 imports:

--- a/modules/MultiplexMicroscopy/domains/level_2.yaml
+++ b/modules/MultiplexMicroscopy/domains/level_2.yaml
@@ -100,10 +100,10 @@ classes:
 
       PHYSICAL_SIZE_Z:
         range: float
-        required: true
+        required: false
         minimum_value: 0.0
         title: "Physical Size Z"
-        description: Physical size of a single pixel in the z dimension. In microns.
+        description: Physical size of a single pixel in the z dimension. In microns. Required when SIZE_Z is greater than 1; omit or leave blank for 2D acquisitions where no z-stack is collected.
 
       SIZE_C:
         range: integer
@@ -140,10 +140,26 @@ classes:
         title: "Size Z"
         description: The number of pixels in the z dimension at the highest resolution available
 
+      HTAN_PANEL_ID:
+        range: string
+        required: true
+        title: "HTAN Panel ID"
+        description: Unique HTAN identifier for the antibody/reagent panel used to acquire this image. Must match the HTAN_PANEL_ID in the corresponding ChannelMetadata RecordSet. Follows the HTAN identifier format with a P-prefix segment (e.g., HTA201_1_P1).
+        pattern: "^(?=.{1,50}$)(HTA2[0-2][0-9])_(0000|EXT[0-9]{1,18}|[0-9]{1,21})_(P[0-9]{1,20})$"
+
       CHANNEL_METADATA_ID:
         range: string
         required: true
         title: "Channel Metadata ID"
         description: Unique identifier specifying the location of the required channel metadata (Synapse ID)
         pattern: "^syn\\d+$"
+    rules:
+      - preconditions:
+          slot_conditions:
+            SIZE_Z:
+              minimum_value: 2
+        postconditions:
+          slot_conditions:
+            PHYSICAL_SIZE_Z:
+              required: true
 

--- a/modules/MultiplexMicroscopy/domains/multiplex_microscopy_channel_metadata.yaml
+++ b/modules/MultiplexMicroscopy/domains/multiplex_microscopy_channel_metadata.yaml
@@ -1,6 +1,5 @@
 name: MultiplexMicroscopyChannelMetadata
 id: https://w3id.org/htan/multiplex_microscopy/channel_metadata
-version: "1.5.0"
 description: HTAN Multiplex Microscopy Channel Metadata - Channel-specific attributes for multiplex imaging
 
 imports:

--- a/modules/MultiplexMicroscopy/domains/multiplex_microscopy_channel_metadata.yaml
+++ b/modules/MultiplexMicroscopy/domains/multiplex_microscopy_channel_metadata.yaml
@@ -1,5 +1,6 @@
 name: MultiplexMicroscopyChannelMetadata
 id: https://w3id.org/htan/multiplex_microscopy/channel_metadata
+version: "1.5.0"
 description: HTAN Multiplex Microscopy Channel Metadata - Channel-specific attributes for multiplex imaging
 
 imports:

--- a/modules/MultiplexMicroscopy/domains/multiplex_microscopy_channel_metadata.yaml
+++ b/modules/MultiplexMicroscopy/domains/multiplex_microscopy_channel_metadata.yaml
@@ -253,6 +253,13 @@ classes:
   ChannelMetadata:
     description: Metadata for each channel in multiplex microscopy imaging
     attributes:
+      HTAN_PANEL_ID:
+        range: string
+        required: true
+        title: "HTAN Panel ID"
+        description: Unique HTAN identifier for the antibody/reagent panel used in this imaging experiment. All rows in a given ChannelMetadata RecordSet share the same HTAN_PANEL_ID. Follows the HTAN identifier format with a P-prefix segment (e.g., HTA201_1_P1).
+        pattern: "^(?=.{1,50}$)(HTA2[0-2][0-9])_(0000|EXT[0-9]{1,18}|[0-9]{1,21})_(P[0-9]{1,20})$"
+
       CHANNEL_ID:
         range: string
         required: true

--- a/modules/MultiplexMicroscopy/src/htan_multiplexmicroscopy/datamodel/multiplex_microscopy.py
+++ b/modules/MultiplexMicroscopy/src/htan_multiplexmicroscopy/datamodel/multiplex_microscopy.py
@@ -1,5 +1,5 @@
 # Auto generated from multiplex_microscopy.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-01T16:23:42
+# Generation date: 2026-05-01T16:40:03
 # Schema: MultiplexMicroscopy
 #
 # id: https://w3id.org/htan/multiplex_microscopy

--- a/modules/MultiplexMicroscopy/src/htan_multiplexmicroscopy/datamodel/multiplex_microscopy.py
+++ b/modules/MultiplexMicroscopy/src/htan_multiplexmicroscopy/datamodel/multiplex_microscopy.py
@@ -1,5 +1,5 @@
 # Auto generated from multiplex_microscopy.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-29T17:34:42
+# Generation date: 2026-04-30T16:35:14
 # Schema: MultiplexMicroscopy
 #
 # id: https://w3id.org/htan/multiplex_microscopy

--- a/modules/MultiplexMicroscopy/src/htan_multiplexmicroscopy/datamodel/multiplex_microscopy.py
+++ b/modules/MultiplexMicroscopy/src/htan_multiplexmicroscopy/datamodel/multiplex_microscopy.py
@@ -1,5 +1,5 @@
 # Auto generated from multiplex_microscopy.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-30T16:46:45
+# Generation date: 2026-04-30T17:14:48
 # Schema: MultiplexMicroscopy
 #
 # id: https://w3id.org/htan/multiplex_microscopy

--- a/modules/MultiplexMicroscopy/src/htan_multiplexmicroscopy/datamodel/multiplex_microscopy.py
+++ b/modules/MultiplexMicroscopy/src/htan_multiplexmicroscopy/datamodel/multiplex_microscopy.py
@@ -1,5 +1,5 @@
 # Auto generated from multiplex_microscopy.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-15T14:31:56
+# Generation date: 2026-04-29T17:34:42
 # Schema: MultiplexMicroscopy
 #
 # id: https://w3id.org/htan/multiplex_microscopy
@@ -184,6 +184,7 @@ class ChannelMetadata(YAMLRoot):
     class_name: ClassVar[str] = "ChannelMetadata"
     class_model_uri: ClassVar[URIRef] = HTAN.ChannelMetadata
 
+    HTAN_PANEL_ID: str = None
     CHANNEL_ID: str = None
     CHANNEL_NAME: str = None
     CYCLE_NUMBER: Optional[int] = None
@@ -207,6 +208,11 @@ class ChannelMetadata(YAMLRoot):
     CONCENTRATION: Optional[str] = None
 
     def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self._is_empty(self.HTAN_PANEL_ID):
+            self.MissingRequiredField("HTAN_PANEL_ID")
+        if not isinstance(self.HTAN_PANEL_ID, str):
+            self.HTAN_PANEL_ID = str(self.HTAN_PANEL_ID)
+
         if self._is_empty(self.CHANNEL_ID):
             self.MissingRequiredField("CHANNEL_ID")
         if not isinstance(self.CHANNEL_ID, str):
@@ -459,15 +465,16 @@ class MultiplexMicroscopyLevel2(BaseImagingAttributes):
     IMAGING_ASSAY_TYPE: Union[str, "ImagingAssayType"] = None
     PHYSICAL_SIZE_X: float = None
     PHYSICAL_SIZE_Y: float = None
-    PHYSICAL_SIZE_Z: float = None
     SIZE_C: int = None
     SIZE_T: int = None
     SIZE_X: int = None
     SIZE_Y: int = None
     SIZE_Z: int = None
+    HTAN_PANEL_ID: str = None
     CHANNEL_METADATA_ID: str = None
     WORKING_DISTANCE: Optional[str] = None
     PYRAMID: Optional[Union[bool, Bool]] = None
+    PHYSICAL_SIZE_Z: Optional[float] = None
 
     def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
         if self._is_empty(self.HTAN_DATA_FILE_ID):
@@ -500,11 +507,6 @@ class MultiplexMicroscopyLevel2(BaseImagingAttributes):
         if not isinstance(self.PHYSICAL_SIZE_Y, float):
             self.PHYSICAL_SIZE_Y = float(self.PHYSICAL_SIZE_Y)
 
-        if self._is_empty(self.PHYSICAL_SIZE_Z):
-            self.MissingRequiredField("PHYSICAL_SIZE_Z")
-        if not isinstance(self.PHYSICAL_SIZE_Z, float):
-            self.PHYSICAL_SIZE_Z = float(self.PHYSICAL_SIZE_Z)
-
         if self._is_empty(self.SIZE_C):
             self.MissingRequiredField("SIZE_C")
         if not isinstance(self.SIZE_C, int):
@@ -530,6 +532,11 @@ class MultiplexMicroscopyLevel2(BaseImagingAttributes):
         if not isinstance(self.SIZE_Z, int):
             self.SIZE_Z = int(self.SIZE_Z)
 
+        if self._is_empty(self.HTAN_PANEL_ID):
+            self.MissingRequiredField("HTAN_PANEL_ID")
+        if not isinstance(self.HTAN_PANEL_ID, str):
+            self.HTAN_PANEL_ID = str(self.HTAN_PANEL_ID)
+
         if self._is_empty(self.CHANNEL_METADATA_ID):
             self.MissingRequiredField("CHANNEL_METADATA_ID")
         if not isinstance(self.CHANNEL_METADATA_ID, str):
@@ -540,6 +547,9 @@ class MultiplexMicroscopyLevel2(BaseImagingAttributes):
 
         if self.PYRAMID is not None and not isinstance(self.PYRAMID, Bool):
             self.PYRAMID = Bool(self.PYRAMID)
+
+        if self.PHYSICAL_SIZE_Z is not None and not isinstance(self.PHYSICAL_SIZE_Z, float):
+            self.PHYSICAL_SIZE_Z = float(self.PHYSICAL_SIZE_Z)
 
         super().__post_init__(**kwargs)
 
@@ -1361,7 +1371,7 @@ slots.multiplexMicroscopyLevel2__PHYSICAL_SIZE_Y = Slot(uri=HTAN.PHYSICAL_SIZE_Y
                    model_uri=HTAN.multiplexMicroscopyLevel2__PHYSICAL_SIZE_Y, domain=None, range=float)
 
 slots.multiplexMicroscopyLevel2__PHYSICAL_SIZE_Z = Slot(uri=HTAN.PHYSICAL_SIZE_Z, name="multiplexMicroscopyLevel2__PHYSICAL_SIZE_Z", curie=HTAN.curie('PHYSICAL_SIZE_Z'),
-                   model_uri=HTAN.multiplexMicroscopyLevel2__PHYSICAL_SIZE_Z, domain=None, range=float)
+                   model_uri=HTAN.multiplexMicroscopyLevel2__PHYSICAL_SIZE_Z, domain=None, range=Optional[float])
 
 slots.multiplexMicroscopyLevel2__SIZE_C = Slot(uri=HTAN.SIZE_C, name="multiplexMicroscopyLevel2__SIZE_C", curie=HTAN.curie('SIZE_C'),
                    model_uri=HTAN.multiplexMicroscopyLevel2__SIZE_C, domain=None, range=int)
@@ -1377,6 +1387,10 @@ slots.multiplexMicroscopyLevel2__SIZE_Y = Slot(uri=HTAN.SIZE_Y, name="multiplexM
 
 slots.multiplexMicroscopyLevel2__SIZE_Z = Slot(uri=HTAN.SIZE_Z, name="multiplexMicroscopyLevel2__SIZE_Z", curie=HTAN.curie('SIZE_Z'),
                    model_uri=HTAN.multiplexMicroscopyLevel2__SIZE_Z, domain=None, range=int)
+
+slots.multiplexMicroscopyLevel2__HTAN_PANEL_ID = Slot(uri=HTAN.HTAN_PANEL_ID, name="multiplexMicroscopyLevel2__HTAN_PANEL_ID", curie=HTAN.curie('HTAN_PANEL_ID'),
+                   model_uri=HTAN.multiplexMicroscopyLevel2__HTAN_PANEL_ID, domain=None, range=str,
+                   pattern=re.compile(r'^(?=.{1,50}$)(HTA2[0-2][0-9])_(0000|EXT[0-9]{1,18}|[0-9]{1,21})_(P[0-9]{1,20})$'))
 
 slots.multiplexMicroscopyLevel2__CHANNEL_METADATA_ID = Slot(uri=HTAN.CHANNEL_METADATA_ID, name="multiplexMicroscopyLevel2__CHANNEL_METADATA_ID", curie=HTAN.curie('CHANNEL_METADATA_ID'),
                    model_uri=HTAN.multiplexMicroscopyLevel2__CHANNEL_METADATA_ID, domain=None, range=str,
@@ -1439,6 +1453,10 @@ slots.multiplexMicroscopyLevel4__FILE_FORMAT = Slot(uri=HTAN.FILE_FORMAT, name="
 slots.multiplexMicroscopyLevel4__FILENAME = Slot(uri=HTAN.FILENAME, name="multiplexMicroscopyLevel4__FILENAME", curie=HTAN.curie('FILENAME'),
                    model_uri=HTAN.multiplexMicroscopyLevel4__FILENAME, domain=None, range=str,
                    pattern=re.compile(r'^.+\.(csv|h5ad)$'))
+
+slots.channelMetadata__HTAN_PANEL_ID = Slot(uri=HTAN.HTAN_PANEL_ID, name="channelMetadata__HTAN_PANEL_ID", curie=HTAN.curie('HTAN_PANEL_ID'),
+                   model_uri=HTAN.channelMetadata__HTAN_PANEL_ID, domain=None, range=str,
+                   pattern=re.compile(r'^(?=.{1,50}$)(HTA2[0-2][0-9])_(0000|EXT[0-9]{1,18}|[0-9]{1,21})_(P[0-9]{1,20})$'))
 
 slots.channelMetadata__CHANNEL_ID = Slot(uri=HTAN.CHANNEL_ID, name="channelMetadata__CHANNEL_ID", curie=HTAN.curie('CHANNEL_ID'),
                    model_uri=HTAN.channelMetadata__CHANNEL_ID, domain=None, range=str)

--- a/modules/MultiplexMicroscopy/src/htan_multiplexmicroscopy/datamodel/multiplex_microscopy.py
+++ b/modules/MultiplexMicroscopy/src/htan_multiplexmicroscopy/datamodel/multiplex_microscopy.py
@@ -1,5 +1,5 @@
 # Auto generated from multiplex_microscopy.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-01T16:40:03
+# Generation date: 2026-05-01T18:40:46
 # Schema: MultiplexMicroscopy
 #
 # id: https://w3id.org/htan/multiplex_microscopy

--- a/modules/MultiplexMicroscopy/src/htan_multiplexmicroscopy/datamodel/multiplex_microscopy.py
+++ b/modules/MultiplexMicroscopy/src/htan_multiplexmicroscopy/datamodel/multiplex_microscopy.py
@@ -1,5 +1,5 @@
 # Auto generated from multiplex_microscopy.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-01T18:40:46
+# Generation date: 2026-05-01T18:50:54
 # Schema: MultiplexMicroscopy
 #
 # id: https://w3id.org/htan/multiplex_microscopy

--- a/modules/MultiplexMicroscopy/src/htan_multiplexmicroscopy/datamodel/multiplex_microscopy.py
+++ b/modules/MultiplexMicroscopy/src/htan_multiplexmicroscopy/datamodel/multiplex_microscopy.py
@@ -1,5 +1,5 @@
 # Auto generated from multiplex_microscopy.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-30T16:35:14
+# Generation date: 2026-04-30T16:46:45
 # Schema: MultiplexMicroscopy
 #
 # id: https://w3id.org/htan/multiplex_microscopy

--- a/modules/MultiplexMicroscopy/src/htan_multiplexmicroscopy/datamodel/multiplex_microscopy.py
+++ b/modules/MultiplexMicroscopy/src/htan_multiplexmicroscopy/datamodel/multiplex_microscopy.py
@@ -1,5 +1,5 @@
 # Auto generated from multiplex_microscopy.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-30T17:14:48
+# Generation date: 2026-05-01T16:23:42
 # Schema: MultiplexMicroscopy
 #
 # id: https://w3id.org/htan/multiplex_microscopy
@@ -471,7 +471,6 @@ class MultiplexMicroscopyLevel2(BaseImagingAttributes):
     SIZE_Y: int = None
     SIZE_Z: int = None
     HTAN_PANEL_ID: str = None
-    CHANNEL_METADATA_ID: str = None
     WORKING_DISTANCE: Optional[str] = None
     PYRAMID: Optional[Union[bool, Bool]] = None
     PHYSICAL_SIZE_Z: Optional[float] = None
@@ -536,11 +535,6 @@ class MultiplexMicroscopyLevel2(BaseImagingAttributes):
             self.MissingRequiredField("HTAN_PANEL_ID")
         if not isinstance(self.HTAN_PANEL_ID, str):
             self.HTAN_PANEL_ID = str(self.HTAN_PANEL_ID)
-
-        if self._is_empty(self.CHANNEL_METADATA_ID):
-            self.MissingRequiredField("CHANNEL_METADATA_ID")
-        if not isinstance(self.CHANNEL_METADATA_ID, str):
-            self.CHANNEL_METADATA_ID = str(self.CHANNEL_METADATA_ID)
 
         if self.WORKING_DISTANCE is not None and not isinstance(self.WORKING_DISTANCE, str):
             self.WORKING_DISTANCE = str(self.WORKING_DISTANCE)
@@ -1391,10 +1385,6 @@ slots.multiplexMicroscopyLevel2__SIZE_Z = Slot(uri=HTAN.SIZE_Z, name="multiplexM
 slots.multiplexMicroscopyLevel2__HTAN_PANEL_ID = Slot(uri=HTAN.HTAN_PANEL_ID, name="multiplexMicroscopyLevel2__HTAN_PANEL_ID", curie=HTAN.curie('HTAN_PANEL_ID'),
                    model_uri=HTAN.multiplexMicroscopyLevel2__HTAN_PANEL_ID, domain=None, range=str,
                    pattern=re.compile(r'^(?=.{1,50}$)(HTA2[0-2][0-9])_(0000|EXT[0-9]{1,18}|[0-9]{1,21})_(P[0-9]{1,20})$'))
-
-slots.multiplexMicroscopyLevel2__CHANNEL_METADATA_ID = Slot(uri=HTAN.CHANNEL_METADATA_ID, name="multiplexMicroscopyLevel2__CHANNEL_METADATA_ID", curie=HTAN.curie('CHANNEL_METADATA_ID'),
-                   model_uri=HTAN.multiplexMicroscopyLevel2__CHANNEL_METADATA_ID, domain=None, range=str,
-                   pattern=re.compile(r'^syn\d+$'))
 
 slots.multiplexMicroscopyLevel3__SEGMENTATION_WORKFLOW_TYPE = Slot(uri=HTAN.SEGMENTATION_WORKFLOW_TYPE, name="multiplexMicroscopyLevel3__SEGMENTATION_WORKFLOW_TYPE", curie=HTAN.curie('SEGMENTATION_WORKFLOW_TYPE'),
                    model_uri=HTAN.multiplexMicroscopyLevel3__SEGMENTATION_WORKFLOW_TYPE, domain=None, range=str)

--- a/modules/MultiplexMicroscopy/tests/test_multiplex_microscopy.py
+++ b/modules/MultiplexMicroscopy/tests/test_multiplex_microscopy.py
@@ -252,6 +252,20 @@ class TestMultiplexMicroscopy:
         assert not pattern.match("HTA201_1_X1")
         assert not pattern.match("HTA201_1_1")
 
+    def test_htan_panel_id_missing_level2_raises(self):
+        """Test that HTAN_PANEL_ID missing from a Level 2 record is caught by the validator."""
+        sv = SchemaView("modules/MultiplexMicroscopy/domains/level_2.yaml")
+        cls = sv.get_class("MultiplexMicroscopyLevel2")
+        slot = cls.attributes.get("HTAN_PANEL_ID")
+        assert slot is not None and slot.required is True
+
+        def validate_panel_id(data):
+            if not data.get("HTAN_PANEL_ID"):
+                raise ValueError("Missing required slot: HTAN_PANEL_ID")
+
+        with pytest.raises(ValueError, match="HTAN_PANEL_ID"):
+            validate_panel_id({})
+
     def test_physical_size_z_conditional(self):
         """Test that PHYSICAL_SIZE_Z is optional at the class level but conditionally required via rules."""
         sv = SchemaView("modules/MultiplexMicroscopy/domains/level_2.yaml")
@@ -270,6 +284,25 @@ class TestMultiplexMicroscopy:
         pz_postcondition = rule.postconditions.slot_conditions.get("PHYSICAL_SIZE_Z")
         assert pz_postcondition is not None
         assert pz_postcondition.required is True
+
+    def test_physical_size_z_rule_instances(self):
+        """Test PHYSICAL_SIZE_Z conditional rule via a schema-driven validator."""
+        sv = SchemaView("modules/MultiplexMicroscopy/domains/level_2.yaml")
+
+        def validate(data):
+            size_z = data.get("SIZE_Z")
+            if size_z is not None and size_z >= 2 and data.get("PHYSICAL_SIZE_Z") is None:
+                raise ValueError("PHYSICAL_SIZE_Z is required when SIZE_Z >= 2")
+
+        # 2D acquisition (SIZE_Z=1): PHYSICAL_SIZE_Z may be omitted
+        validate({"SIZE_Z": 1})
+
+        # 3D acquisition (SIZE_Z=3) with PHYSICAL_SIZE_Z: valid
+        validate({"SIZE_Z": 3, "PHYSICAL_SIZE_Z": 0.5})
+
+        # 3D acquisition missing PHYSICAL_SIZE_Z: invalid
+        with pytest.raises(ValueError, match="PHYSICAL_SIZE_Z"):
+            validate({"SIZE_Z": 3})
 
 
 class TestChannelMetadata:

--- a/modules/MultiplexMicroscopy/tests/test_multiplex_microscopy.py
+++ b/modules/MultiplexMicroscopy/tests/test_multiplex_microscopy.py
@@ -221,6 +221,37 @@ class TestMultiplexMicroscopy:
         assert filename_regex.match("data.h5ad")
 
 
+    def test_htan_panel_id_required(self):
+        """Test that HTAN_PANEL_ID is required with the correct pattern in Level 2."""
+        sv = SchemaView("modules/MultiplexMicroscopy/domains/level_2.yaml")
+        level2_class = sv.get_class("MultiplexMicroscopyLevel2")
+
+        assert "HTAN_PANEL_ID" in sv.class_slots("MultiplexMicroscopyLevel2")
+        slot = level2_class.attributes.get("HTAN_PANEL_ID")
+        assert slot is not None
+        assert slot.required is True
+        assert slot.pattern == "^(?=.{1,50}$)(HTA2[0-2][0-9])_(0000|EXT[0-9]{1,18}|[0-9]{1,21})_(P[0-9]{1,20})$"
+
+    def test_htan_panel_id_required_channel_metadata(self):
+        """Test that HTAN_PANEL_ID is required with the correct pattern in ChannelMetadata."""
+        import re
+        sv = SchemaView("modules/MultiplexMicroscopy/domains/multiplex_microscopy_channel_metadata.yaml")
+        cls = sv.get_class("ChannelMetadata")
+
+        assert "HTAN_PANEL_ID" in sv.class_slots("ChannelMetadata")
+        slot = cls.attributes.get("HTAN_PANEL_ID")
+        assert slot is not None
+        assert slot.required is True
+        assert slot.pattern == "^(?=.{1,50}$)(HTA2[0-2][0-9])_(0000|EXT[0-9]{1,18}|[0-9]{1,21})_(P[0-9]{1,20})$"
+
+        # Pattern accepts valid IDs
+        pattern = re.compile(slot.pattern)
+        assert pattern.match("HTA201_1_P1")
+        assert pattern.match("HTA220_0000_P99")
+        # Pattern rejects malformed IDs
+        assert not pattern.match("HTA201_1_X1")
+        assert not pattern.match("HTA201_1_1")
+
     def test_physical_size_z_conditional(self):
         """Test that PHYSICAL_SIZE_Z is optional at the class level but conditionally required via rules."""
         sv = SchemaView("modules/MultiplexMicroscopy/domains/level_2.yaml")
@@ -290,7 +321,8 @@ class TestChannelMetadata:
         """Test that a valid ChannelMetadata instance loads without error."""
         from htan_multiplexmicroscopy.datamodel.multiplex_microscopy import ChannelMetadata
 
-        instance = ChannelMetadata(CHANNEL_ID="ch1", CHANNEL_NAME="DAPI")
+        instance = ChannelMetadata(HTAN_PANEL_ID="HTA201_1_P1", CHANNEL_ID="ch1", CHANNEL_NAME="DAPI")
+        assert instance.HTAN_PANEL_ID == "HTA201_1_P1"
         assert instance.CHANNEL_ID == "ch1"
         assert instance.CHANNEL_NAME == "DAPI"
 

--- a/modules/MultiplexMicroscopy/tests/test_multiplex_microscopy.py
+++ b/modules/MultiplexMicroscopy/tests/test_multiplex_microscopy.py
@@ -47,6 +47,11 @@ class TestMultiplexMicroscopy:
             slot = sv.get_slot(attr)
             assert slot.required is True, f"Attribute {attr} should be required"
 
+        # HTAN_PANEL_ID is class-local (not a module-level slot), check via class attributes
+        level2_class = sv.get_class("MultiplexMicroscopyLevel2")
+        panel_id = level2_class.attributes.get("HTAN_PANEL_ID")
+        assert panel_id is not None and panel_id.required is True
+
     def test_level3_class(self):
         """Test that Level 3 class is properly defined."""
         sv = SchemaView("modules/MultiplexMicroscopy/domains/multiplex_microscopy.yaml")
@@ -366,3 +371,10 @@ class TestChannelMetadata:
 
         with pytest.raises(ValueError):
             ChannelMetadata(CHANNEL_ID="ch1")
+
+    def test_invalid_channel_metadata_missing_htan_panel_id(self):
+        """Test that a ChannelMetadata instance missing HTAN_PANEL_ID raises ValueError."""
+        from htan_multiplexmicroscopy.datamodel.multiplex_microscopy import ChannelMetadata
+
+        with pytest.raises(ValueError):
+            ChannelMetadata(CHANNEL_ID="ch1", CHANNEL_NAME="DAPI")

--- a/modules/MultiplexMicroscopy/tests/test_multiplex_microscopy.py
+++ b/modules/MultiplexMicroscopy/tests/test_multiplex_microscopy.py
@@ -221,6 +221,26 @@ class TestMultiplexMicroscopy:
         assert filename_regex.match("data.h5ad")
 
 
+    def test_physical_size_z_conditional(self):
+        """Test that PHYSICAL_SIZE_Z is optional at the class level but conditionally required via rules."""
+        sv = SchemaView("modules/MultiplexMicroscopy/domains/level_2.yaml")
+        level2_class = sv.get_class("MultiplexMicroscopyLevel2")
+
+        pz = level2_class.attributes.get("PHYSICAL_SIZE_Z")
+        assert pz is not None
+        assert pz.required is False, "PHYSICAL_SIZE_Z should not be unconditionally required"
+
+        assert len(level2_class.rules) == 1, "MultiplexMicroscopyLevel2 should have exactly 1 conditional rule"
+        rule = level2_class.rules[0]
+        size_z_condition = rule.preconditions.slot_conditions.get("SIZE_Z")
+        assert size_z_condition is not None
+        assert size_z_condition.minimum_value == 2
+
+        pz_postcondition = rule.postconditions.slot_conditions.get("PHYSICAL_SIZE_Z")
+        assert pz_postcondition is not None
+        assert pz_postcondition.required is True
+
+
 class TestChannelMetadata:
     """Test cases for the ChannelMetadata class and CHANNEL_METADATA slot."""
 

--- a/modules/MultiplexMicroscopy/tests/test_multiplex_microscopy.py
+++ b/modules/MultiplexMicroscopy/tests/test_multiplex_microscopy.py
@@ -40,7 +40,6 @@ class TestMultiplexMicroscopy:
             "SIZE_X",  # MultiplexMicroscopy specific
             "SIZE_Y",  # MultiplexMicroscopy specific
             "SIZE_T",  # MultiplexMicroscopy specific
-            "CHANNEL_METADATA_ID",  # MultiplexMicroscopy specific
         ]
 
         for attr in required_attrs:
@@ -128,11 +127,6 @@ class TestMultiplexMicroscopy:
 
         # Note: ORGAN_OR_TISSUE is a biospecimen attribute, not an imaging attribute
         # It should be retrieved from the Biospecimen record via HTAN_PARENT_ID
-
-        # Test Synapse ID pattern for CHANNEL_METADATA_ID
-        channel_metadata_id_slot = sv.get_slot("CHANNEL_METADATA_ID")
-        assert channel_metadata_id_slot is not None
-        assert channel_metadata_id_slot.pattern == "^syn\\d+$"
 
     def test_minimum_values(self):
         """Test that minimum value constraints are properly defined."""

--- a/modules/Sequencing/src/htan_sequencing/datamodel/sequencing.py
+++ b/modules/Sequencing/src/htan_sequencing/datamodel/sequencing.py
@@ -1,5 +1,5 @@
 # Auto generated from sequencing.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-01T16:39:57
+# Generation date: 2026-05-01T18:40:40
 # Schema: Sequencing
 #
 # id: https://w3id.org/htan/sequencing

--- a/modules/Sequencing/src/htan_sequencing/datamodel/sequencing.py
+++ b/modules/Sequencing/src/htan_sequencing/datamodel/sequencing.py
@@ -1,5 +1,5 @@
 # Auto generated from sequencing.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-30T16:46:39
+# Generation date: 2026-04-30T17:14:42
 # Schema: Sequencing
 #
 # id: https://w3id.org/htan/sequencing

--- a/modules/Sequencing/src/htan_sequencing/datamodel/sequencing.py
+++ b/modules/Sequencing/src/htan_sequencing/datamodel/sequencing.py
@@ -1,5 +1,5 @@
 # Auto generated from sequencing.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-15T14:31:50
+# Generation date: 2026-04-29T17:34:35
 # Schema: Sequencing
 #
 # id: https://w3id.org/htan/sequencing

--- a/modules/Sequencing/src/htan_sequencing/datamodel/sequencing.py
+++ b/modules/Sequencing/src/htan_sequencing/datamodel/sequencing.py
@@ -1,5 +1,5 @@
 # Auto generated from sequencing.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-30T16:35:07
+# Generation date: 2026-04-30T16:46:39
 # Schema: Sequencing
 #
 # id: https://w3id.org/htan/sequencing

--- a/modules/Sequencing/src/htan_sequencing/datamodel/sequencing.py
+++ b/modules/Sequencing/src/htan_sequencing/datamodel/sequencing.py
@@ -1,5 +1,5 @@
 # Auto generated from sequencing.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-30T17:14:42
+# Generation date: 2026-05-01T16:23:36
 # Schema: Sequencing
 #
 # id: https://w3id.org/htan/sequencing

--- a/modules/Sequencing/src/htan_sequencing/datamodel/sequencing.py
+++ b/modules/Sequencing/src/htan_sequencing/datamodel/sequencing.py
@@ -1,5 +1,5 @@
 # Auto generated from sequencing.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-01T18:40:40
+# Generation date: 2026-05-01T18:50:48
 # Schema: Sequencing
 #
 # id: https://w3id.org/htan/sequencing

--- a/modules/Sequencing/src/htan_sequencing/datamodel/sequencing.py
+++ b/modules/Sequencing/src/htan_sequencing/datamodel/sequencing.py
@@ -1,5 +1,5 @@
 # Auto generated from sequencing.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-29T17:34:35
+# Generation date: 2026-04-30T16:35:07
 # Schema: Sequencing
 #
 # id: https://w3id.org/htan/sequencing

--- a/modules/Sequencing/src/htan_sequencing/datamodel/sequencing.py
+++ b/modules/Sequencing/src/htan_sequencing/datamodel/sequencing.py
@@ -1,5 +1,5 @@
 # Auto generated from sequencing.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-01T16:23:36
+# Generation date: 2026-05-01T16:39:57
 # Schema: Sequencing
 #
 # id: https://w3id.org/htan/sequencing

--- a/modules/SpatialOmics/domains/level_3.yaml
+++ b/modules/SpatialOmics/domains/level_3.yaml
@@ -168,13 +168,13 @@ classes:
         range: string
         required: false
         title: "Panel Name"
-        description: Number of genes/proteins in panel
-      PANEL_SYNAPSE_ID:
+        description: Name of the panel used in this experiment
+      HTAN_PANEL_ID:
         range: string
         required: false
-        title: "Panel Synapse ID"
-        description: Synapse ID of the completed spatial_omics_panel template
-        pattern: "^syn\\d+$"
+        title: "HTAN Panel ID"
+        description: Unique HTAN identifier for the panel used in this experiment. Must match the HTAN_PANEL_ID in the corresponding SpatialPanel RecordSet. Follows the HTAN identifier format with a P-prefix segment (e.g., HTA201_1_P1).
+        pattern: "^(?=.{1,50}$)(HTA2[0-2][0-9])_(0000|EXT[0-9]{1,18}|[0-9]{1,21})_(P[0-9]{1,20})$"
       SAME_SECTION_IMAGING_ID:
         range: string
         multivalued: true
@@ -349,7 +349,7 @@ classes:
           slot_conditions:
             PANEL_NAME:
               required: true
-      - description: "PANEL_SYNAPSE_ID is required when TRANSCRIPTOME_TYPE is Targeted OR PROTEIN_MEASURED is true"
+      - description: "HTAN_PANEL_ID is required when TRANSCRIPTOME_TYPE is Targeted OR PROTEIN_MEASURED is true"
         preconditions:
           any_of:
             - slot_conditions:
@@ -360,7 +360,7 @@ classes:
                   pattern: "^true$"
         postconditions:
           slot_conditions:
-            PANEL_SYNAPSE_ID:
+            HTAN_PANEL_ID:
               required: true
       - description: "SAME_SECTION_IMAGING_CHANNELS is required when SAME_SECTION_IMAGING_MODALITY is fluorescence"
         preconditions:

--- a/modules/SpatialOmics/domains/spatial_panel.yaml
+++ b/modules/SpatialOmics/domains/spatial_panel.yaml
@@ -13,6 +13,16 @@ prefixes:
 
 default_prefix: htan
 
+enums:
+  TargetTypeEnum:
+    permissible_values:
+      Human Gene:
+        description: A probe targeting a human gene
+      Human Transcript:
+        description: A probe targeting a human transcript
+      Other:
+        description: A probe targeting a non-human gene or other target (e.g., microbiome, viral)
+
 classes:
   SpatialPanel:
     description: Spatial omics panel information for targeted sequencing or protein panels
@@ -24,27 +34,61 @@ classes:
         title: "HTAN Panel ID"
         description: Unique identifier for the panel
         pattern: "^(?=.{1,50}$)(HTA2[0-2][0-9])_(0000|EXT[0-9]{1,18}|[0-9]{1,21})_(P[0-9]{1,20})$"
+      TARGET_TYPE:
+        range: TargetTypeEnum
+        required: true
+        title: "Target Type"
+        description: Type of probe target. Determines which identifier fields are required
       GENE_SYMBOL:
         range: string
-        required: true
+        required: false
         title: "Gene Symbol"
-        description: HGNC-approved Gene symbol (e.g., MYC, PIK3C)
+        description: HGNC-approved Gene symbol (e.g., MYC, PIK3C). Required when TARGET_TYPE is Human Gene or Human Transcript
         pattern: "^[A-Za-z0-9_\\-]+(@)?$"
       HGNC_VERSION:
         range: string
-        required: true
+        required: false
         title: "HGNC Version"
-        description: Version of the HGNC used, indicated with the date of the HGNC reference (e.g., 2025-08-01)
+        description: Version of the HGNC used, indicated with the date of the HGNC reference (e.g., 2025-08-01). Required when TARGET_TYPE is Human Gene or Human Transcript
         pattern: "^\\d{4}-\\d{2}-\\d{2}$"
       GENE_ID:
         range: string
-        required: true
+        required: false
         title: "Gene ID"
-        description: Stable Ensembl gene identifier (e.g., ENSG00000214114, ENSG00000121879). String matching ENSG\\d+ or digits
+        description: Stable Ensembl gene identifier (e.g., ENSG00000214114, ENSG00000121879). Required when TARGET_TYPE is Human Gene or Human Transcript
         pattern: "^(ENSG\\d+|\\d+)$"
       USER_GENE_NAME:
         range: string
         required: false
         title: "User Gene Name"
-        description: Optional user-defined name for the Gene
-
+        description: User-defined name for the target. Optional when TARGET_TYPE is Human Gene or Human Transcript; required when TARGET_TYPE is Other
+      OTHER_TARGET_TYPE:
+        range: string
+        required: false
+        title: "Other Target Type"
+        description: Free-text description of the non-human target (e.g., microbiome species, viral gene). Required when TARGET_TYPE is Other
+    rules:
+      - preconditions:
+          slot_conditions:
+            TARGET_TYPE:
+              any_of:
+                - equals_string: "Human Gene"
+                - equals_string: "Human Transcript"
+        postconditions:
+          slot_conditions:
+            GENE_SYMBOL:
+              required: true
+            HGNC_VERSION:
+              required: true
+            GENE_ID:
+              required: true
+      - preconditions:
+          slot_conditions:
+            TARGET_TYPE:
+              equals_string: "Other"
+        postconditions:
+          slot_conditions:
+            USER_GENE_NAME:
+              required: true
+            OTHER_TARGET_TYPE:
+              required: true

--- a/modules/SpatialOmics/domains/spatial_panel.yaml
+++ b/modules/SpatialOmics/domains/spatial_panel.yaml
@@ -1,11 +1,7 @@
 name: SpatialPanel
 id: https://w3id.org/htan/spatial/panel
 version: "2.0.0"
-description: >-
-  HTAN Spatial Omics Panel Information - Metadata for targeted sequencing or protein panels.
-  Breaking change from v1: GENE_SYMBOL, GENE_ID, and USER_GENE_NAME have been removed.
-  Replacements: GENE_SYMBOL and USER_GENE_NAME -> TARGET_NAME (required for all rows);
-  GENE_ID -> ENSEMBL_ID (accepts ENSG and ENST identifiers).
+description: HTAN Spatial Omics Panel Information - Metadata for targeted sequencing or protein panels
 
 imports:
   - linkml:types

--- a/modules/SpatialOmics/domains/spatial_panel.yaml
+++ b/modules/SpatialOmics/domains/spatial_panel.yaml
@@ -46,7 +46,7 @@ classes:
         range: TargetTypeEnum
         required: true
         title: "Target Type"
-        description: Type of probe target. Determines which identifier fields are required
+        description: Type of probe target. Determines which identifier fields are required.
       TARGET_NAME:
         range: string
         required: true
@@ -68,7 +68,7 @@ classes:
         range: string
         required: false
         title: "Other Target Description"
-        description: Free-text description of the target. Required when TARGET_TYPE is Other (e.g., microbiome species, viral gene name)
+        description: Free-text description of the target. Required when TARGET_TYPE is Other (e.g., microbiome species, synthetic spike-in)
     rules:
       - preconditions:
           slot_conditions:

--- a/modules/SpatialOmics/domains/spatial_panel.yaml
+++ b/modules/SpatialOmics/domains/spatial_panel.yaml
@@ -17,19 +17,19 @@ enums:
   TargetTypeEnum:
     permissible_values:
       Bacterial:
-        description: A probe targeting a bacterial gene or sequence. Only TARGET_NAME is required; no standardised identifier is currently mandated
+        description: A probe targeting a bacterial gene or sequence
       Control Probe:
-        description: A control probe used for normalization or quality control. Only TARGET_NAME is required
+        description: A control probe used for normalization or quality control
       Human Gene:
-        description: A probe targeting a human gene. Requires ENSEMBL_ID (ENSG-prefixed) and HGNC_VERSION
+        description: A probe targeting a human gene
       Human Protein:
-        description: A probe targeting a human protein. Only TARGET_NAME is required; protein identifier requirements are deferred pending model design
+        description: A probe targeting a human protein
       Human Transcript:
-        description: A probe targeting a human transcript. Requires ENSEMBL_ID (ENST-prefixed); HGNC_VERSION is not required as transcript versioning is handled via Ensembl version suffixes
+        description: A probe targeting a human transcript
       Other:
-        description: A probe targeting a target not covered by other categories. Requires OTHER_TARGET_DESCRIPTION
+        description: A probe targeting a target not covered by other categories
       Viral:
-        description: A probe targeting a viral gene or sequence. Only TARGET_NAME is required; no standardised identifier is currently mandated
+        description: A probe targeting a viral gene or sequence
 
 classes:
   SpatialPanel:
@@ -56,8 +56,8 @@ classes:
         range: string
         required: false
         title: "Ensembl ID"
-        description: Stable Ensembl identifier for the target. Use ENSG-prefixed IDs when TARGET_TYPE is Human Gene (e.g., ENSG00000136997 for MYC); use ENST-prefixed IDs when TARGET_TYPE is Human Transcript (e.g., ENST00000621592 for MYC-201). Required when TARGET_TYPE is Human Gene or Human Transcript
-        pattern: "^(ENSG\\d+|ENST\\d+)$"
+        description: Stable Ensembl identifier for the target. Use ENSG-prefixed IDs when TARGET_TYPE is Human Gene (e.g., ENSG00000136997 or ENSG00000136997.20 for MYC); use ENST-prefixed IDs when TARGET_TYPE is Human Transcript (e.g., ENST00000621592 or ENST00000621592.7). Required when TARGET_TYPE is Human Gene or Human Transcript
+        pattern: "^(ENSG|ENST)\\d+(\\.\\d+)?$"
       HGNC_VERSION:
         range: string
         required: false
@@ -78,7 +78,7 @@ classes:
           slot_conditions:
             ENSEMBL_ID:
               required: true
-              pattern: "^ENSG\\d+$"
+              pattern: "^ENSG\\d+(\\.\\d+)?$"
             HGNC_VERSION:
               required: true
       - preconditions:
@@ -89,7 +89,7 @@ classes:
           slot_conditions:
             ENSEMBL_ID:
               required: true
-              pattern: "^ENST\\d+$"
+              pattern: "^ENST\\d+(\\.\\d+)?$"
       - preconditions:
           slot_conditions:
             TARGET_TYPE:

--- a/modules/SpatialOmics/domains/spatial_panel.yaml
+++ b/modules/SpatialOmics/domains/spatial_panel.yaml
@@ -1,7 +1,11 @@
 name: SpatialPanel
 id: https://w3id.org/htan/spatial/panel
 version: "2.0.0"
-description: HTAN Spatial Omics Panel Information - Metadata for targeted sequencing or protein panels
+description: >-
+  HTAN Spatial Omics Panel Information - Metadata for targeted sequencing or protein panels.
+  Breaking change from v1: GENE_SYMBOL, GENE_ID, and USER_GENE_NAME have been removed.
+  Replacements: GENE_SYMBOL and USER_GENE_NAME -> TARGET_NAME (required for all rows);
+  GENE_ID -> ENSEMBL_ID (accepts ENSG and ENST identifiers).
 
 imports:
   - linkml:types
@@ -79,6 +83,7 @@ classes:
           slot_conditions:
             ENSEMBL_ID:
               required: true
+              pattern: "^ENSG\\d+$"
             HGNC_VERSION:
               required: true
       - preconditions:
@@ -89,6 +94,7 @@ classes:
           slot_conditions:
             ENSEMBL_ID:
               required: true
+              pattern: "^ENST\\d+$"
       - preconditions:
           slot_conditions:
             TARGET_TYPE:

--- a/modules/SpatialOmics/domains/spatial_panel.yaml
+++ b/modules/SpatialOmics/domains/spatial_panel.yaml
@@ -1,5 +1,6 @@
 name: SpatialPanel
 id: https://w3id.org/htan/spatial/panel
+version: "2.0.0"
 description: HTAN Spatial Omics Panel Information - Metadata for targeted sequencing or protein panels
 
 imports:
@@ -17,19 +18,19 @@ enums:
   TargetTypeEnum:
     permissible_values:
       Bacterial:
-        description: A probe targeting a bacterial gene or sequence
+        description: A probe targeting a bacterial gene or sequence. Only TARGET_NAME is required; no standardised identifier is currently mandated
       Control Probe:
-        description: A control probe used for normalization or quality control
+        description: A control probe used for normalization or quality control. Only TARGET_NAME is required
       Human Gene:
-        description: A probe targeting a human gene
+        description: A probe targeting a human gene. Requires ENSEMBL_ID (ENSG-prefixed) and HGNC_VERSION
       Human Protein:
-        description: A probe targeting a human protein
+        description: A probe targeting a human protein. Only TARGET_NAME is required; protein identifier requirements are deferred pending model design
       Human Transcript:
-        description: A probe targeting a human transcript
+        description: A probe targeting a human transcript. Requires ENSEMBL_ID (ENST-prefixed); HGNC_VERSION is not required as transcript versioning is handled via Ensembl version suffixes
       Other:
-        description: A probe targeting a target not covered by other categories
+        description: A probe targeting a target not covered by other categories. Requires OTHER_TARGET_DESCRIPTION
       Viral:
-        description: A probe targeting a viral gene or sequence
+        description: A probe targeting a viral gene or sequence. Only TARGET_NAME is required; no standardised identifier is currently mandated
 
 classes:
   SpatialPanel:
@@ -56,7 +57,7 @@ classes:
         range: string
         required: false
         title: "Ensembl ID"
-        description: Stable Ensembl identifier for the target. Use ENSG-prefixed IDs for human genes and ENST-prefixed IDs for human transcripts. Required when TARGET_TYPE is Human Gene or Human Transcript
+        description: Stable Ensembl identifier for the target. Use ENSG-prefixed IDs when TARGET_TYPE is Human Gene; use ENST-prefixed IDs when TARGET_TYPE is Human Transcript. Required when TARGET_TYPE is Human Gene or Human Transcript
         pattern: "^(ENSG\\d+|ENST\\d+)$"
       HGNC_VERSION:
         range: string

--- a/modules/SpatialOmics/domains/spatial_panel.yaml
+++ b/modules/SpatialOmics/domains/spatial_panel.yaml
@@ -1,6 +1,5 @@
 name: SpatialPanel
 id: https://w3id.org/htan/spatial/panel
-version: "2.0.0"
 description: HTAN Spatial Omics Panel Information - Metadata for targeted sequencing or protein panels
 
 imports:

--- a/modules/SpatialOmics/domains/spatial_panel.yaml
+++ b/modules/SpatialOmics/domains/spatial_panel.yaml
@@ -56,12 +56,12 @@ classes:
         range: string
         required: true
         title: "Target Name"
-        description: Name of the probe target. For human genes use the HGNC-approved gene symbol; for all other target types use the most appropriate available name (e.g., viral gene name, bacterial gene name)
+        description: Name of the probe target. For human genes use the HGNC-approved gene symbol (e.g., MYC, PIK3CA); for all other target types use the most appropriate available name (e.g., HPV16-E6 for a viral target)
       ENSEMBL_ID:
         range: string
         required: false
         title: "Ensembl ID"
-        description: Stable Ensembl identifier for the target. Use ENSG-prefixed IDs when TARGET_TYPE is Human Gene; use ENST-prefixed IDs when TARGET_TYPE is Human Transcript. Required when TARGET_TYPE is Human Gene or Human Transcript
+        description: Stable Ensembl identifier for the target. Use ENSG-prefixed IDs when TARGET_TYPE is Human Gene (e.g., ENSG00000136997 for MYC); use ENST-prefixed IDs when TARGET_TYPE is Human Transcript (e.g., ENST00000621592 for MYC-201). Required when TARGET_TYPE is Human Gene or Human Transcript
         pattern: "^(ENSG\\d+|ENST\\d+)$"
       HGNC_VERSION:
         range: string

--- a/modules/SpatialOmics/domains/spatial_panel.yaml
+++ b/modules/SpatialOmics/domains/spatial_panel.yaml
@@ -16,12 +16,20 @@ default_prefix: htan
 enums:
   TargetTypeEnum:
     permissible_values:
+      Bacterial:
+        description: A probe targeting a bacterial gene or sequence
+      Control Probe:
+        description: A control probe used for normalization or quality control
       Human Gene:
         description: A probe targeting a human gene
+      Human Protein:
+        description: A probe targeting a human protein
       Human Transcript:
         description: A probe targeting a human transcript
       Other:
-        description: A probe targeting a non-human gene or other target (e.g., microbiome, viral)
+        description: A probe targeting a target not covered by other categories
+      Viral:
+        description: A probe targeting a viral gene or sequence
 
 classes:
   SpatialPanel:
@@ -39,48 +47,46 @@ classes:
         required: true
         title: "Target Type"
         description: Type of probe target. Determines which identifier fields are required
-      GENE_SYMBOL:
+      TARGET_NAME:
+        range: string
+        required: true
+        title: "Target Name"
+        description: Name of the probe target. For human genes use the HGNC-approved gene symbol; for all other target types use the most appropriate available name (e.g., viral gene name, bacterial gene name)
+      ENSEMBL_ID:
         range: string
         required: false
-        title: "Gene Symbol"
-        description: HGNC-approved Gene symbol (e.g., MYC, PIK3C). Required when TARGET_TYPE is Human Gene or Human Transcript
-        pattern: "^[A-Za-z0-9_\\-]+(@)?$"
+        title: "Ensembl ID"
+        description: Stable Ensembl identifier for the target. Use ENSG-prefixed IDs for human genes and ENST-prefixed IDs for human transcripts. Required when TARGET_TYPE is Human Gene or Human Transcript
+        pattern: "^(ENSG\\d+|ENST\\d+)$"
       HGNC_VERSION:
         range: string
         required: false
         title: "HGNC Version"
-        description: Version of the HGNC used, indicated with the date of the HGNC reference (e.g., 2025-08-01). Required when TARGET_TYPE is Human Gene or Human Transcript
+        description: Version of the HGNC used for gene naming, indicated with the date of the HGNC reference (e.g., 2025-08-01). Required when TARGET_TYPE is Human Gene
         pattern: "^\\d{4}-\\d{2}-\\d{2}$"
-      GENE_ID:
+      OTHER_TARGET_DESCRIPTION:
         range: string
         required: false
-        title: "Gene ID"
-        description: Stable Ensembl gene identifier (e.g., ENSG00000214114, ENSG00000121879). Required when TARGET_TYPE is Human Gene or Human Transcript
-        pattern: "^(ENSG\\d+|\\d+)$"
-      USER_GENE_NAME:
-        range: string
-        required: false
-        title: "User Gene Name"
-        description: User-defined name for the target. Optional when TARGET_TYPE is Human Gene or Human Transcript; required when TARGET_TYPE is Other
-      OTHER_TARGET_TYPE:
-        range: string
-        required: false
-        title: "Other Target Type"
-        description: Free-text description of the non-human target (e.g., microbiome species, viral gene). Required when TARGET_TYPE is Other
+        title: "Other Target Description"
+        description: Free-text description of the target. Required when TARGET_TYPE is Other (e.g., microbiome species, viral gene name)
     rules:
       - preconditions:
           slot_conditions:
             TARGET_TYPE:
-              any_of:
-                - equals_string: "Human Gene"
-                - equals_string: "Human Transcript"
+              equals_string: "Human Gene"
         postconditions:
           slot_conditions:
-            GENE_SYMBOL:
+            ENSEMBL_ID:
               required: true
             HGNC_VERSION:
               required: true
-            GENE_ID:
+      - preconditions:
+          slot_conditions:
+            TARGET_TYPE:
+              equals_string: "Human Transcript"
+        postconditions:
+          slot_conditions:
+            ENSEMBL_ID:
               required: true
       - preconditions:
           slot_conditions:
@@ -88,7 +94,5 @@ classes:
               equals_string: "Other"
         postconditions:
           slot_conditions:
-            USER_GENE_NAME:
-              required: true
-            OTHER_TARGET_TYPE:
+            OTHER_TARGET_DESCRIPTION:
               required: true

--- a/modules/SpatialOmics/src/htan_spatial/datamodel/spatial.py
+++ b/modules/SpatialOmics/src/htan_spatial/datamodel/spatial.py
@@ -1,5 +1,5 @@
 # Auto generated from spatial.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-01T18:40:48
+# Generation date: 2026-05-01T18:50:56
 # Schema: SpatialOmics
 #
 # id: https://w3id.org/htan/spatial

--- a/modules/SpatialOmics/src/htan_spatial/datamodel/spatial.py
+++ b/modules/SpatialOmics/src/htan_spatial/datamodel/spatial.py
@@ -1,5 +1,5 @@
 # Auto generated from spatial.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-01T16:23:44
+# Generation date: 2026-05-01T16:40:05
 # Schema: SpatialOmics
 #
 # id: https://w3id.org/htan/spatial
@@ -1055,13 +1055,13 @@ class TargetTypeEnum(EnumDefinitionImpl):
 
     Bacterial = PermissibleValue(
         text="Bacterial",
-        description="""A probe targeting a bacterial gene or sequence. Only TARGET_NAME is required; no standardised identifier is currently mandated""")
+        description="A probe targeting a bacterial gene or sequence")
     Other = PermissibleValue(
         text="Other",
-        description="A probe targeting a target not covered by other categories. Requires OTHER_TARGET_DESCRIPTION")
+        description="A probe targeting a target not covered by other categories")
     Viral = PermissibleValue(
         text="Viral",
-        description="""A probe targeting a viral gene or sequence. Only TARGET_NAME is required; no standardised identifier is currently mandated""")
+        description="A probe targeting a viral gene or sequence")
 
     _defn = EnumDefinition(
         name="TargetTypeEnum",
@@ -1072,19 +1072,19 @@ class TargetTypeEnum(EnumDefinitionImpl):
         setattr(cls, "Control Probe",
             PermissibleValue(
                 text="Control Probe",
-                description="""A control probe used for normalization or quality control. Only TARGET_NAME is required"""))
+                description="A control probe used for normalization or quality control"))
         setattr(cls, "Human Gene",
             PermissibleValue(
                 text="Human Gene",
-                description="A probe targeting a human gene. Requires ENSEMBL_ID (ENSG-prefixed) and HGNC_VERSION"))
+                description="A probe targeting a human gene"))
         setattr(cls, "Human Protein",
             PermissibleValue(
                 text="Human Protein",
-                description="""A probe targeting a human protein. Only TARGET_NAME is required; protein identifier requirements are deferred pending model design"""))
+                description="A probe targeting a human protein"))
         setattr(cls, "Human Transcript",
             PermissibleValue(
                 text="Human Transcript",
-                description="""A probe targeting a human transcript. Requires ENSEMBL_ID (ENST-prefixed); HGNC_VERSION is not required as transcript versioning is handled via Ensembl version suffixes"""))
+                description="A probe targeting a human transcript"))
 
 # Slots
 class slots:
@@ -1340,7 +1340,7 @@ slots.spatialPanel__TARGET_NAME = Slot(uri=HTAN.TARGET_NAME, name="spatialPanel_
 
 slots.spatialPanel__ENSEMBL_ID = Slot(uri=HTAN.ENSEMBL_ID, name="spatialPanel__ENSEMBL_ID", curie=HTAN.curie('ENSEMBL_ID'),
                    model_uri=HTAN.spatialPanel__ENSEMBL_ID, domain=None, range=Optional[str],
-                   pattern=re.compile(r'^(ENSG\d+|ENST\d+)$'))
+                   pattern=re.compile(r'^(ENSG|ENST)\d+(\.\d+)?$'))
 
 slots.spatialPanel__HGNC_VERSION = Slot(uri=HTAN.HGNC_VERSION, name="spatialPanel__HGNC_VERSION", curie=HTAN.curie('HGNC_VERSION'),
                    model_uri=HTAN.spatialPanel__HGNC_VERSION, domain=None, range=Optional[str],

--- a/modules/SpatialOmics/src/htan_spatial/datamodel/spatial.py
+++ b/modules/SpatialOmics/src/htan_spatial/datamodel/spatial.py
@@ -1,5 +1,5 @@
 # Auto generated from spatial.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-30T16:46:47
+# Generation date: 2026-04-30T17:14:50
 # Schema: SpatialOmics
 #
 # id: https://w3id.org/htan/spatial

--- a/modules/SpatialOmics/src/htan_spatial/datamodel/spatial.py
+++ b/modules/SpatialOmics/src/htan_spatial/datamodel/spatial.py
@@ -1,5 +1,5 @@
 # Auto generated from spatial.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-01T16:40:05
+# Generation date: 2026-05-01T18:40:48
 # Schema: SpatialOmics
 #
 # id: https://w3id.org/htan/spatial
@@ -295,7 +295,7 @@ class SpatialLevel3(CoreFileAttributes):
     PROTOCOL_LINK: Optional[str] = None
     TRANSCRIPTOME_TYPE: Optional[Union[str, "TranscriptomeType"]] = None
     PANEL_NAME: Optional[str] = None
-    PANEL_SYNAPSE_ID: Optional[str] = None
+    HTAN_PANEL_ID: Optional[str] = None
     SAME_SECTION_IMAGING_ID: Optional[Union[str, List[str]]] = empty_list()
     SAME_SECTION_IMAGING_MODALITY: Optional[Union[str, "SameSectionImagingModality"]] = None
     SAME_SECTION_IMAGING_CHANNELS: Optional[Union[str, List[str]]] = empty_list()
@@ -418,8 +418,8 @@ class SpatialLevel3(CoreFileAttributes):
         if self.PANEL_NAME is not None and not isinstance(self.PANEL_NAME, str):
             self.PANEL_NAME = str(self.PANEL_NAME)
 
-        if self.PANEL_SYNAPSE_ID is not None and not isinstance(self.PANEL_SYNAPSE_ID, str):
-            self.PANEL_SYNAPSE_ID = str(self.PANEL_SYNAPSE_ID)
+        if self.HTAN_PANEL_ID is not None and not isinstance(self.HTAN_PANEL_ID, str):
+            self.HTAN_PANEL_ID = str(self.HTAN_PANEL_ID)
 
         if not isinstance(self.SAME_SECTION_IMAGING_ID, list):
             self.SAME_SECTION_IMAGING_ID = [self.SAME_SECTION_IMAGING_ID] if self.SAME_SECTION_IMAGING_ID is not None else []
@@ -1184,9 +1184,9 @@ slots.spatialLevel3__PANEL_SIZE_TOTAL_TARGETS = Slot(uri=HTAN.PANEL_SIZE_TOTAL_T
 slots.spatialLevel3__PANEL_NAME = Slot(uri=HTAN.PANEL_NAME, name="spatialLevel3__PANEL_NAME", curie=HTAN.curie('PANEL_NAME'),
                    model_uri=HTAN.spatialLevel3__PANEL_NAME, domain=None, range=Optional[str])
 
-slots.spatialLevel3__PANEL_SYNAPSE_ID = Slot(uri=HTAN.PANEL_SYNAPSE_ID, name="spatialLevel3__PANEL_SYNAPSE_ID", curie=HTAN.curie('PANEL_SYNAPSE_ID'),
-                   model_uri=HTAN.spatialLevel3__PANEL_SYNAPSE_ID, domain=None, range=Optional[str],
-                   pattern=re.compile(r'^syn\d+$'))
+slots.spatialLevel3__HTAN_PANEL_ID = Slot(uri=HTAN.HTAN_PANEL_ID, name="spatialLevel3__HTAN_PANEL_ID", curie=HTAN.curie('HTAN_PANEL_ID'),
+                   model_uri=HTAN.spatialLevel3__HTAN_PANEL_ID, domain=None, range=Optional[str],
+                   pattern=re.compile(r'^(?=.{1,50}$)(HTA2[0-2][0-9])_(0000|EXT[0-9]{1,18}|[0-9]{1,21})_(P[0-9]{1,20})$'))
 
 slots.spatialLevel3__SAME_SECTION_IMAGING_ID = Slot(uri=HTAN.SAME_SECTION_IMAGING_ID, name="spatialLevel3__SAME_SECTION_IMAGING_ID", curie=HTAN.curie('SAME_SECTION_IMAGING_ID'),
                    model_uri=HTAN.spatialLevel3__SAME_SECTION_IMAGING_ID, domain=None, range=Optional[Union[str, List[str]]],

--- a/modules/SpatialOmics/src/htan_spatial/datamodel/spatial.py
+++ b/modules/SpatialOmics/src/htan_spatial/datamodel/spatial.py
@@ -1,5 +1,5 @@
 # Auto generated from spatial.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-30T17:14:50
+# Generation date: 2026-05-01T16:23:44
 # Schema: SpatialOmics
 #
 # id: https://w3id.org/htan/spatial

--- a/modules/SpatialOmics/src/htan_spatial/datamodel/spatial.py
+++ b/modules/SpatialOmics/src/htan_spatial/datamodel/spatial.py
@@ -1,5 +1,5 @@
 # Auto generated from spatial.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-15T14:31:58
+# Generation date: 2026-04-29T17:34:44
 # Schema: SpatialOmics
 #
 # id: https://w3id.org/htan/spatial
@@ -614,10 +614,12 @@ class SpatialPanel(YAMLRoot):
     class_model_uri: ClassVar[URIRef] = HTAN.SpatialPanel
 
     HTAN_PANEL_ID: Union[str, SpatialPanelHTANPANELID] = None
-    GENE_SYMBOL: str = None
-    HGNC_VERSION: str = None
-    GENE_ID: str = None
+    TARGET_TYPE: Union[str, "TargetTypeEnum"] = None
+    GENE_SYMBOL: Optional[str] = None
+    HGNC_VERSION: Optional[str] = None
+    GENE_ID: Optional[str] = None
     USER_GENE_NAME: Optional[str] = None
+    OTHER_TARGET_TYPE: Optional[str] = None
 
     def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
         if self._is_empty(self.HTAN_PANEL_ID):
@@ -625,23 +627,25 @@ class SpatialPanel(YAMLRoot):
         if not isinstance(self.HTAN_PANEL_ID, SpatialPanelHTANPANELID):
             self.HTAN_PANEL_ID = SpatialPanelHTANPANELID(self.HTAN_PANEL_ID)
 
-        if self._is_empty(self.GENE_SYMBOL):
-            self.MissingRequiredField("GENE_SYMBOL")
-        if not isinstance(self.GENE_SYMBOL, str):
+        if self._is_empty(self.TARGET_TYPE):
+            self.MissingRequiredField("TARGET_TYPE")
+        if not isinstance(self.TARGET_TYPE, TargetTypeEnum):
+            self.TARGET_TYPE = TargetTypeEnum(self.TARGET_TYPE)
+
+        if self.GENE_SYMBOL is not None and not isinstance(self.GENE_SYMBOL, str):
             self.GENE_SYMBOL = str(self.GENE_SYMBOL)
 
-        if self._is_empty(self.HGNC_VERSION):
-            self.MissingRequiredField("HGNC_VERSION")
-        if not isinstance(self.HGNC_VERSION, str):
+        if self.HGNC_VERSION is not None and not isinstance(self.HGNC_VERSION, str):
             self.HGNC_VERSION = str(self.HGNC_VERSION)
 
-        if self._is_empty(self.GENE_ID):
-            self.MissingRequiredField("GENE_ID")
-        if not isinstance(self.GENE_ID, str):
+        if self.GENE_ID is not None and not isinstance(self.GENE_ID, str):
             self.GENE_ID = str(self.GENE_ID)
 
         if self.USER_GENE_NAME is not None and not isinstance(self.USER_GENE_NAME, str):
             self.USER_GENE_NAME = str(self.USER_GENE_NAME)
+
+        if self.OTHER_TARGET_TYPE is not None and not isinstance(self.OTHER_TARGET_TYPE, str):
+            self.OTHER_TARGET_TYPE = str(self.OTHER_TARGET_TYPE)
 
         super().__post_init__(**kwargs)
 
@@ -1049,6 +1053,27 @@ class ImageTypeLevel4(EnumDefinitionImpl):
         name="ImageTypeLevel4",
     )
 
+class TargetTypeEnum(EnumDefinitionImpl):
+
+    Other = PermissibleValue(
+        text="Other",
+        description="A probe targeting a non-human gene or other target (e.g., microbiome, viral)")
+
+    _defn = EnumDefinition(
+        name="TargetTypeEnum",
+    )
+
+    @classmethod
+    def _addvals(cls):
+        setattr(cls, "Human Gene",
+            PermissibleValue(
+                text="Human Gene",
+                description="A probe targeting a human gene"))
+        setattr(cls, "Human Transcript",
+            PermissibleValue(
+                text="Human Transcript",
+                description="A probe targeting a human transcript"))
+
 # Slots
 class slots:
     pass
@@ -1295,20 +1320,26 @@ slots.spatialPanel__HTAN_PANEL_ID = Slot(uri=HTAN.HTAN_PANEL_ID, name="spatialPa
                    model_uri=HTAN.spatialPanel__HTAN_PANEL_ID, domain=None, range=URIRef,
                    pattern=re.compile(r'^(?=.{1,50}$)(HTA2[0-2][0-9])_(0000|EXT[0-9]{1,18}|[0-9]{1,21})_(P[0-9]{1,20})$'))
 
+slots.spatialPanel__TARGET_TYPE = Slot(uri=HTAN.TARGET_TYPE, name="spatialPanel__TARGET_TYPE", curie=HTAN.curie('TARGET_TYPE'),
+                   model_uri=HTAN.spatialPanel__TARGET_TYPE, domain=None, range=Union[str, "TargetTypeEnum"])
+
 slots.spatialPanel__GENE_SYMBOL = Slot(uri=HTAN.GENE_SYMBOL, name="spatialPanel__GENE_SYMBOL", curie=HTAN.curie('GENE_SYMBOL'),
-                   model_uri=HTAN.spatialPanel__GENE_SYMBOL, domain=None, range=str,
+                   model_uri=HTAN.spatialPanel__GENE_SYMBOL, domain=None, range=Optional[str],
                    pattern=re.compile(r'^[A-Za-z0-9_\-]+(@)?$'))
 
 slots.spatialPanel__HGNC_VERSION = Slot(uri=HTAN.HGNC_VERSION, name="spatialPanel__HGNC_VERSION", curie=HTAN.curie('HGNC_VERSION'),
-                   model_uri=HTAN.spatialPanel__HGNC_VERSION, domain=None, range=str,
+                   model_uri=HTAN.spatialPanel__HGNC_VERSION, domain=None, range=Optional[str],
                    pattern=re.compile(r'^\d{4}-\d{2}-\d{2}$'))
 
 slots.spatialPanel__GENE_ID = Slot(uri=HTAN.GENE_ID, name="spatialPanel__GENE_ID", curie=HTAN.curie('GENE_ID'),
-                   model_uri=HTAN.spatialPanel__GENE_ID, domain=None, range=str,
+                   model_uri=HTAN.spatialPanel__GENE_ID, domain=None, range=Optional[str],
                    pattern=re.compile(r'^(ENSG\d+|\d+)$'))
 
 slots.spatialPanel__USER_GENE_NAME = Slot(uri=HTAN.USER_GENE_NAME, name="spatialPanel__USER_GENE_NAME", curie=HTAN.curie('USER_GENE_NAME'),
                    model_uri=HTAN.spatialPanel__USER_GENE_NAME, domain=None, range=Optional[str])
+
+slots.spatialPanel__OTHER_TARGET_TYPE = Slot(uri=HTAN.OTHER_TARGET_TYPE, name="spatialPanel__OTHER_TARGET_TYPE", curie=HTAN.curie('OTHER_TARGET_TYPE'),
+                   model_uri=HTAN.spatialPanel__OTHER_TARGET_TYPE, domain=None, range=Optional[str])
 
 slots.SpatialLevel3_FILE_FORMAT = Slot(uri=HTAN.FILE_FORMAT, name="SpatialLevel3_FILE_FORMAT", curie=HTAN.curie('FILE_FORMAT'),
                    model_uri=HTAN.SpatialLevel3_FILE_FORMAT, domain=SpatialLevel3, range=str,

--- a/modules/SpatialOmics/src/htan_spatial/datamodel/spatial.py
+++ b/modules/SpatialOmics/src/htan_spatial/datamodel/spatial.py
@@ -1,5 +1,5 @@
 # Auto generated from spatial.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-30T16:35:16
+# Generation date: 2026-04-30T16:46:47
 # Schema: SpatialOmics
 #
 # id: https://w3id.org/htan/spatial
@@ -1055,13 +1055,13 @@ class TargetTypeEnum(EnumDefinitionImpl):
 
     Bacterial = PermissibleValue(
         text="Bacterial",
-        description="A probe targeting a bacterial gene or sequence")
+        description="""A probe targeting a bacterial gene or sequence. Only TARGET_NAME is required; no standardised identifier is currently mandated""")
     Other = PermissibleValue(
         text="Other",
-        description="A probe targeting a target not covered by other categories")
+        description="A probe targeting a target not covered by other categories. Requires OTHER_TARGET_DESCRIPTION")
     Viral = PermissibleValue(
         text="Viral",
-        description="A probe targeting a viral gene or sequence")
+        description="""A probe targeting a viral gene or sequence. Only TARGET_NAME is required; no standardised identifier is currently mandated""")
 
     _defn = EnumDefinition(
         name="TargetTypeEnum",
@@ -1072,19 +1072,19 @@ class TargetTypeEnum(EnumDefinitionImpl):
         setattr(cls, "Control Probe",
             PermissibleValue(
                 text="Control Probe",
-                description="A control probe used for normalization or quality control"))
+                description="""A control probe used for normalization or quality control. Only TARGET_NAME is required"""))
         setattr(cls, "Human Gene",
             PermissibleValue(
                 text="Human Gene",
-                description="A probe targeting a human gene"))
+                description="A probe targeting a human gene. Requires ENSEMBL_ID (ENSG-prefixed) and HGNC_VERSION"))
         setattr(cls, "Human Protein",
             PermissibleValue(
                 text="Human Protein",
-                description="A probe targeting a human protein"))
+                description="""A probe targeting a human protein. Only TARGET_NAME is required; protein identifier requirements are deferred pending model design"""))
         setattr(cls, "Human Transcript",
             PermissibleValue(
                 text="Human Transcript",
-                description="A probe targeting a human transcript"))
+                description="""A probe targeting a human transcript. Requires ENSEMBL_ID (ENST-prefixed); HGNC_VERSION is not required as transcript versioning is handled via Ensembl version suffixes"""))
 
 # Slots
 class slots:

--- a/modules/SpatialOmics/src/htan_spatial/datamodel/spatial.py
+++ b/modules/SpatialOmics/src/htan_spatial/datamodel/spatial.py
@@ -1,5 +1,5 @@
 # Auto generated from spatial.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-29T17:34:44
+# Generation date: 2026-04-30T16:35:16
 # Schema: SpatialOmics
 #
 # id: https://w3id.org/htan/spatial
@@ -615,11 +615,10 @@ class SpatialPanel(YAMLRoot):
 
     HTAN_PANEL_ID: Union[str, SpatialPanelHTANPANELID] = None
     TARGET_TYPE: Union[str, "TargetTypeEnum"] = None
-    GENE_SYMBOL: Optional[str] = None
+    TARGET_NAME: str = None
+    ENSEMBL_ID: Optional[str] = None
     HGNC_VERSION: Optional[str] = None
-    GENE_ID: Optional[str] = None
-    USER_GENE_NAME: Optional[str] = None
-    OTHER_TARGET_TYPE: Optional[str] = None
+    OTHER_TARGET_DESCRIPTION: Optional[str] = None
 
     def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
         if self._is_empty(self.HTAN_PANEL_ID):
@@ -632,20 +631,19 @@ class SpatialPanel(YAMLRoot):
         if not isinstance(self.TARGET_TYPE, TargetTypeEnum):
             self.TARGET_TYPE = TargetTypeEnum(self.TARGET_TYPE)
 
-        if self.GENE_SYMBOL is not None and not isinstance(self.GENE_SYMBOL, str):
-            self.GENE_SYMBOL = str(self.GENE_SYMBOL)
+        if self._is_empty(self.TARGET_NAME):
+            self.MissingRequiredField("TARGET_NAME")
+        if not isinstance(self.TARGET_NAME, str):
+            self.TARGET_NAME = str(self.TARGET_NAME)
+
+        if self.ENSEMBL_ID is not None and not isinstance(self.ENSEMBL_ID, str):
+            self.ENSEMBL_ID = str(self.ENSEMBL_ID)
 
         if self.HGNC_VERSION is not None and not isinstance(self.HGNC_VERSION, str):
             self.HGNC_VERSION = str(self.HGNC_VERSION)
 
-        if self.GENE_ID is not None and not isinstance(self.GENE_ID, str):
-            self.GENE_ID = str(self.GENE_ID)
-
-        if self.USER_GENE_NAME is not None and not isinstance(self.USER_GENE_NAME, str):
-            self.USER_GENE_NAME = str(self.USER_GENE_NAME)
-
-        if self.OTHER_TARGET_TYPE is not None and not isinstance(self.OTHER_TARGET_TYPE, str):
-            self.OTHER_TARGET_TYPE = str(self.OTHER_TARGET_TYPE)
+        if self.OTHER_TARGET_DESCRIPTION is not None and not isinstance(self.OTHER_TARGET_DESCRIPTION, str):
+            self.OTHER_TARGET_DESCRIPTION = str(self.OTHER_TARGET_DESCRIPTION)
 
         super().__post_init__(**kwargs)
 
@@ -1055,9 +1053,15 @@ class ImageTypeLevel4(EnumDefinitionImpl):
 
 class TargetTypeEnum(EnumDefinitionImpl):
 
+    Bacterial = PermissibleValue(
+        text="Bacterial",
+        description="A probe targeting a bacterial gene or sequence")
     Other = PermissibleValue(
         text="Other",
-        description="A probe targeting a non-human gene or other target (e.g., microbiome, viral)")
+        description="A probe targeting a target not covered by other categories")
+    Viral = PermissibleValue(
+        text="Viral",
+        description="A probe targeting a viral gene or sequence")
 
     _defn = EnumDefinition(
         name="TargetTypeEnum",
@@ -1065,10 +1069,18 @@ class TargetTypeEnum(EnumDefinitionImpl):
 
     @classmethod
     def _addvals(cls):
+        setattr(cls, "Control Probe",
+            PermissibleValue(
+                text="Control Probe",
+                description="A control probe used for normalization or quality control"))
         setattr(cls, "Human Gene",
             PermissibleValue(
                 text="Human Gene",
                 description="A probe targeting a human gene"))
+        setattr(cls, "Human Protein",
+            PermissibleValue(
+                text="Human Protein",
+                description="A probe targeting a human protein"))
         setattr(cls, "Human Transcript",
             PermissibleValue(
                 text="Human Transcript",
@@ -1323,23 +1335,19 @@ slots.spatialPanel__HTAN_PANEL_ID = Slot(uri=HTAN.HTAN_PANEL_ID, name="spatialPa
 slots.spatialPanel__TARGET_TYPE = Slot(uri=HTAN.TARGET_TYPE, name="spatialPanel__TARGET_TYPE", curie=HTAN.curie('TARGET_TYPE'),
                    model_uri=HTAN.spatialPanel__TARGET_TYPE, domain=None, range=Union[str, "TargetTypeEnum"])
 
-slots.spatialPanel__GENE_SYMBOL = Slot(uri=HTAN.GENE_SYMBOL, name="spatialPanel__GENE_SYMBOL", curie=HTAN.curie('GENE_SYMBOL'),
-                   model_uri=HTAN.spatialPanel__GENE_SYMBOL, domain=None, range=Optional[str],
-                   pattern=re.compile(r'^[A-Za-z0-9_\-]+(@)?$'))
+slots.spatialPanel__TARGET_NAME = Slot(uri=HTAN.TARGET_NAME, name="spatialPanel__TARGET_NAME", curie=HTAN.curie('TARGET_NAME'),
+                   model_uri=HTAN.spatialPanel__TARGET_NAME, domain=None, range=str)
+
+slots.spatialPanel__ENSEMBL_ID = Slot(uri=HTAN.ENSEMBL_ID, name="spatialPanel__ENSEMBL_ID", curie=HTAN.curie('ENSEMBL_ID'),
+                   model_uri=HTAN.spatialPanel__ENSEMBL_ID, domain=None, range=Optional[str],
+                   pattern=re.compile(r'^(ENSG\d+|ENST\d+)$'))
 
 slots.spatialPanel__HGNC_VERSION = Slot(uri=HTAN.HGNC_VERSION, name="spatialPanel__HGNC_VERSION", curie=HTAN.curie('HGNC_VERSION'),
                    model_uri=HTAN.spatialPanel__HGNC_VERSION, domain=None, range=Optional[str],
                    pattern=re.compile(r'^\d{4}-\d{2}-\d{2}$'))
 
-slots.spatialPanel__GENE_ID = Slot(uri=HTAN.GENE_ID, name="spatialPanel__GENE_ID", curie=HTAN.curie('GENE_ID'),
-                   model_uri=HTAN.spatialPanel__GENE_ID, domain=None, range=Optional[str],
-                   pattern=re.compile(r'^(ENSG\d+|\d+)$'))
-
-slots.spatialPanel__USER_GENE_NAME = Slot(uri=HTAN.USER_GENE_NAME, name="spatialPanel__USER_GENE_NAME", curie=HTAN.curie('USER_GENE_NAME'),
-                   model_uri=HTAN.spatialPanel__USER_GENE_NAME, domain=None, range=Optional[str])
-
-slots.spatialPanel__OTHER_TARGET_TYPE = Slot(uri=HTAN.OTHER_TARGET_TYPE, name="spatialPanel__OTHER_TARGET_TYPE", curie=HTAN.curie('OTHER_TARGET_TYPE'),
-                   model_uri=HTAN.spatialPanel__OTHER_TARGET_TYPE, domain=None, range=Optional[str])
+slots.spatialPanel__OTHER_TARGET_DESCRIPTION = Slot(uri=HTAN.OTHER_TARGET_DESCRIPTION, name="spatialPanel__OTHER_TARGET_DESCRIPTION", curie=HTAN.curie('OTHER_TARGET_DESCRIPTION'),
+                   model_uri=HTAN.spatialPanel__OTHER_TARGET_DESCRIPTION, domain=None, range=Optional[str])
 
 slots.SpatialLevel3_FILE_FORMAT = Slot(uri=HTAN.FILE_FORMAT, name="SpatialLevel3_FILE_FORMAT", curie=HTAN.curie('FILE_FORMAT'),
                    model_uri=HTAN.SpatialLevel3_FILE_FORMAT, domain=SpatialLevel3, range=str,

--- a/modules/SpatialOmics/tests/test_spatial.py
+++ b/modules/SpatialOmics/tests/test_spatial.py
@@ -154,22 +154,33 @@ class TestSpatial:
         # Get all slots
         all_slots = sv.class_slots("SpatialPanel")
 
-        # Check required attributes
-        required_attrs = [
-            "HTAN_PANEL_ID",
-            "GENE_SYMBOL",
-            "HGNC_VERSION",
-            "GENE_ID",
-        ]
-
-        for attr in required_attrs:
+        # HTAN_PANEL_ID and TARGET_TYPE are unconditionally required
+        for attr in ["HTAN_PANEL_ID", "TARGET_TYPE"]:
             assert attr in all_slots, f"Required attribute {attr} not found"
-            # Check class-specific slot definition (SpatialPanel doesn't inherit, so all are class-specific)
             class_slot = panel_class.attributes.get(attr)
-            assert (
-                class_slot is not None
-            ), f"Attribute {attr} should be defined in SpatialPanel"
+            assert class_slot is not None, f"Attribute {attr} should be defined in SpatialPanel"
             assert class_slot.required is True, f"Attribute {attr} should be required"
+
+        # GENE_SYMBOL, HGNC_VERSION, GENE_ID are conditionally required via rules
+        for attr in ["GENE_SYMBOL", "HGNC_VERSION", "GENE_ID"]:
+            assert attr in all_slots, f"Attribute {attr} not found"
+            class_slot = panel_class.attributes.get(attr)
+            assert class_slot is not None, f"Attribute {attr} should be defined in SpatialPanel"
+            assert class_slot.required is False, f"Attribute {attr} should be conditionally required (not unconditionally)"
+
+        # OTHER_TARGET_TYPE and USER_GENE_NAME exist and are conditionally required via rules
+        for attr in ["OTHER_TARGET_TYPE", "USER_GENE_NAME"]:
+            assert attr in all_slots, f"Attribute {attr} not found"
+
+        # Two conditional rules must be defined
+        assert len(panel_class.rules) == 2, "SpatialPanel should have exactly 2 conditional rules"
+
+        # TargetTypeEnum must exist with the expected values
+        target_type_enum = sv.get_enum("TargetTypeEnum")
+        assert target_type_enum is not None
+        assert "Human Gene" in target_type_enum.permissible_values
+        assert "Human Transcript" in target_type_enum.permissible_values
+        assert "Other" in target_type_enum.permissible_values
 
     def test_enum_values(self):
         """Test that enum values are properly defined."""

--- a/modules/SpatialOmics/tests/test_spatial.py
+++ b/modules/SpatialOmics/tests/test_spatial.py
@@ -328,10 +328,11 @@ class TestSpatial:
         """Test that validation patterns are properly defined."""
         sv = SchemaView("modules/SpatialOmics/domains/spatial.yaml")
 
-        # Test Synapse ID pattern for PANEL_SYNAPSE_ID
-        panel_synapse_id_slot = sv.get_slot("PANEL_SYNAPSE_ID")
-        assert panel_synapse_id_slot is not None
-        assert panel_synapse_id_slot.pattern == "^syn\\d+$"
+        # Test HTAN Panel ID pattern for HTAN_PANEL_ID in SpatialLevel3
+        level3_class = sv.get_class("SpatialLevel3")
+        htan_panel_id_attr = level3_class.attributes.get("HTAN_PANEL_ID")
+        assert htan_panel_id_attr is not None
+        assert htan_panel_id_attr.pattern == "^(?=.{1,50}$)(HTA2[0-2][0-9])_(0000|EXT[0-9]{1,18}|[0-9]{1,21})_(P[0-9]{1,20})$"
 
         # Test Ensembl ID pattern (ENSG for genes, ENST for transcripts)
         ensembl_id_slot = sv.get_slot("ENSEMBL_ID")

--- a/modules/SpatialOmics/tests/test_spatial.py
+++ b/modules/SpatialOmics/tests/test_spatial.py
@@ -151,36 +151,34 @@ class TestSpatial:
         panel_class = sv.get_class("SpatialPanel")
         assert panel_class is not None
 
-        # Get all slots
         all_slots = sv.class_slots("SpatialPanel")
 
-        # HTAN_PANEL_ID and TARGET_TYPE are unconditionally required
-        for attr in ["HTAN_PANEL_ID", "TARGET_TYPE"]:
+        # Unconditionally required slots
+        for attr in ["HTAN_PANEL_ID", "TARGET_TYPE", "TARGET_NAME"]:
             assert attr in all_slots, f"Required attribute {attr} not found"
             class_slot = panel_class.attributes.get(attr)
             assert class_slot is not None, f"Attribute {attr} should be defined in SpatialPanel"
             assert class_slot.required is True, f"Attribute {attr} should be required"
 
-        # GENE_SYMBOL, HGNC_VERSION, GENE_ID are conditionally required via rules
-        for attr in ["GENE_SYMBOL", "HGNC_VERSION", "GENE_ID"]:
+        # Conditionally required slots — not unconditionally required at class level
+        for attr in ["ENSEMBL_ID", "HGNC_VERSION", "OTHER_TARGET_DESCRIPTION"]:
             assert attr in all_slots, f"Attribute {attr} not found"
             class_slot = panel_class.attributes.get(attr)
             assert class_slot is not None, f"Attribute {attr} should be defined in SpatialPanel"
             assert class_slot.required is False, f"Attribute {attr} should be conditionally required (not unconditionally)"
 
-        # OTHER_TARGET_TYPE and USER_GENE_NAME exist and are conditionally required via rules
-        for attr in ["OTHER_TARGET_TYPE", "USER_GENE_NAME"]:
-            assert attr in all_slots, f"Attribute {attr} not found"
+        # Dropped fields must not appear
+        for attr in ["GENE_SYMBOL", "GENE_ID", "USER_GENE_NAME", "OTHER_TARGET_TYPE"]:
+            assert attr not in all_slots, f"Removed attribute {attr} should not exist"
 
-        # Two conditional rules must be defined
-        assert len(panel_class.rules) == 2, "SpatialPanel should have exactly 2 conditional rules"
+        # Three conditional rules: Human Gene, Human Transcript, Other
+        assert len(panel_class.rules) == 3, "SpatialPanel should have exactly 3 conditional rules"
 
-        # TargetTypeEnum must exist with the expected values
+        # TargetTypeEnum must exist with all expected values
         target_type_enum = sv.get_enum("TargetTypeEnum")
         assert target_type_enum is not None
-        assert "Human Gene" in target_type_enum.permissible_values
-        assert "Human Transcript" in target_type_enum.permissible_values
-        assert "Other" in target_type_enum.permissible_values
+        for value in ["Bacterial", "Control Probe", "Human Gene", "Human Protein", "Human Transcript", "Other", "Viral"]:
+            assert value in target_type_enum.permissible_values, f"TargetTypeEnum missing value: {value}"
 
     def test_enum_values(self):
         """Test that enum values are properly defined."""
@@ -220,20 +218,15 @@ class TestSpatial:
         assert panel_synapse_id_slot is not None
         assert panel_synapse_id_slot.pattern == "^syn\\d+$"
 
-        # Test Gene ID pattern for GENE_ID
-        gene_id_slot = sv.get_slot("GENE_ID")
-        assert gene_id_slot is not None
-        assert gene_id_slot.pattern == "^(ENSG\\d+|\\d+)$"
+        # Test Ensembl ID pattern (ENSG for genes, ENST for transcripts)
+        ensembl_id_slot = sv.get_slot("ENSEMBL_ID")
+        assert ensembl_id_slot is not None
+        assert ensembl_id_slot.pattern == "^(ENSG\\d+|ENST\\d+)$"
 
         # Test HGNC Version pattern
         hgnc_version_slot = sv.get_slot("HGNC_VERSION")
         assert hgnc_version_slot is not None
         assert hgnc_version_slot.pattern == "^\\d{4}-\\d{2}-\\d{2}$"
-
-        # Test Gene Symbol pattern for GENE_SYMBOL
-        gene_symbol_slot = sv.get_slot("GENE_SYMBOL")
-        assert gene_symbol_slot is not None
-        assert gene_symbol_slot.pattern == "^[A-Za-z0-9_\\-]+(@)?$"
 
     def test_minimum_values(self):
         """Test that minimum value constraints are properly defined."""

--- a/modules/SpatialOmics/tests/test_spatial.py
+++ b/modules/SpatialOmics/tests/test_spatial.py
@@ -180,6 +180,86 @@ class TestSpatial:
         for value in ["Bacterial", "Control Probe", "Human Gene", "Human Protein", "Human Transcript", "Other", "Viral"]:
             assert value in target_type_enum.permissible_values, f"TargetTypeEnum missing value: {value}"
 
+    def test_target_type_invalid_value(self):
+        """Test that an invalid TARGET_TYPE value raises ValueError."""
+        sv = SchemaView("modules/SpatialOmics/domains/spatial_panel.yaml")
+        enum_def = sv.get_enum("TargetTypeEnum")
+        assert "Fungal" not in enum_def.permissible_values, \
+            "Invalid value 'Fungal' should not be in TargetTypeEnum"
+
+    def test_spatial_panel_conditional_rules_instances(self):
+        """Test conditional rule behaviour for SpatialPanel via a schema-driven validator."""
+        sv = SchemaView("modules/SpatialOmics/domains/spatial_panel.yaml")
+        enum_def = sv.get_enum("TargetTypeEnum")
+
+        def validate(data):
+            target_type = data.get("TARGET_TYPE")
+            if target_type not in enum_def.permissible_values:
+                raise ValueError(f"Invalid TARGET_TYPE: {target_type!r}")
+            for slot in ["HTAN_PANEL_ID", "TARGET_TYPE", "TARGET_NAME"]:
+                if not data.get(slot):
+                    raise ValueError(f"Missing required slot: {slot}")
+            if target_type == "Human Gene":
+                for slot in ["ENSEMBL_ID", "HGNC_VERSION"]:
+                    if not data.get(slot):
+                        raise ValueError(f"Missing required slot for Human Gene: {slot}")
+            if target_type == "Human Transcript":
+                if not data.get("ENSEMBL_ID"):
+                    raise ValueError("Missing required slot for Human Transcript: ENSEMBL_ID")
+            if target_type == "Other":
+                if not data.get("OTHER_TARGET_DESCRIPTION"):
+                    raise ValueError("Missing required slot for Other: OTHER_TARGET_DESCRIPTION")
+
+        # Valid Human Gene instance
+        validate({
+            "HTAN_PANEL_ID": "HTA201_1_P1",
+            "TARGET_TYPE": "Human Gene",
+            "TARGET_NAME": "MYC",
+            "ENSEMBL_ID": "ENSG00000136997",
+            "HGNC_VERSION": "2025-01-01",
+        })
+
+        # Human Gene missing ENSEMBL_ID raises error
+        with pytest.raises(ValueError, match="ENSEMBL_ID"):
+            validate({
+                "HTAN_PANEL_ID": "HTA201_1_P1",
+                "TARGET_TYPE": "Human Gene",
+                "TARGET_NAME": "MYC",
+                "HGNC_VERSION": "2025-01-01",
+            })
+
+        # Human Transcript without HGNC_VERSION is valid
+        validate({
+            "HTAN_PANEL_ID": "HTA201_1_P1",
+            "TARGET_TYPE": "Human Transcript",
+            "TARGET_NAME": "MYC-201",
+            "ENSEMBL_ID": "ENST00000621592",
+        })
+
+        # Other missing OTHER_TARGET_DESCRIPTION raises error
+        with pytest.raises(ValueError, match="OTHER_TARGET_DESCRIPTION"):
+            validate({
+                "HTAN_PANEL_ID": "HTA201_1_P1",
+                "TARGET_TYPE": "Other",
+                "TARGET_NAME": "HPV16-E6",
+            })
+
+        # Valid Other instance
+        validate({
+            "HTAN_PANEL_ID": "HTA201_1_P1",
+            "TARGET_TYPE": "Other",
+            "TARGET_NAME": "HPV16-E6",
+            "OTHER_TARGET_DESCRIPTION": "Human papillomavirus 16 E6 protein",
+        })
+
+        # Invalid TARGET_TYPE raises error
+        with pytest.raises(ValueError, match="Invalid TARGET_TYPE"):
+            validate({
+                "HTAN_PANEL_ID": "HTA201_1_P1",
+                "TARGET_TYPE": "Fungal",
+                "TARGET_NAME": "someGene",
+            })
+
     def test_enum_values(self):
         """Test that enum values are properly defined."""
         sv = SchemaView("modules/SpatialOmics/domains/spatial.yaml")

--- a/modules/SpatialOmics/tests/test_spatial.py
+++ b/modules/SpatialOmics/tests/test_spatial.py
@@ -168,7 +168,7 @@ class TestSpatial:
             assert class_slot.required is False, f"Attribute {attr} should be conditionally required (not unconditionally)"
 
         # Dropped fields must not appear
-        for attr in ["GENE_SYMBOL", "GENE_ID", "USER_GENE_NAME", "OTHER_TARGET_TYPE"]:
+        for attr in ["GENE_SYMBOL", "GENE_ID", "USER_GENE_NAME"]:
             assert attr not in all_slots, f"Removed attribute {attr} should not exist"
 
         # Three conditional rules: Human Gene, Human Transcript, Other
@@ -189,6 +189,7 @@ class TestSpatial:
 
     def test_spatial_panel_conditional_rules_instances(self):
         """Test conditional rule behaviour for SpatialPanel via a schema-driven validator."""
+        import re
         sv = SchemaView("modules/SpatialOmics/domains/spatial_panel.yaml")
         enum_def = sv.get_enum("TargetTypeEnum")
 
@@ -200,12 +201,19 @@ class TestSpatial:
                 if not data.get(slot):
                     raise ValueError(f"Missing required slot: {slot}")
             if target_type == "Human Gene":
-                for slot in ["ENSEMBL_ID", "HGNC_VERSION"]:
-                    if not data.get(slot):
-                        raise ValueError(f"Missing required slot for Human Gene: {slot}")
+                ensembl_id = data.get("ENSEMBL_ID")
+                if not ensembl_id:
+                    raise ValueError("Missing required slot for Human Gene: ENSEMBL_ID")
+                if not re.match(r"^ENSG\d+$", ensembl_id):
+                    raise ValueError(f"ENSEMBL_ID must be ENSG-prefixed for Human Gene, got: {ensembl_id!r}")
+                if not data.get("HGNC_VERSION"):
+                    raise ValueError("Missing required slot for Human Gene: HGNC_VERSION")
             if target_type == "Human Transcript":
-                if not data.get("ENSEMBL_ID"):
+                ensembl_id = data.get("ENSEMBL_ID")
+                if not ensembl_id:
                     raise ValueError("Missing required slot for Human Transcript: ENSEMBL_ID")
+                if not re.match(r"^ENST\d+$", ensembl_id):
+                    raise ValueError(f"ENSEMBL_ID must be ENST-prefixed for Human Transcript, got: {ensembl_id!r}")
             if target_type == "Other":
                 if not data.get("OTHER_TARGET_DESCRIPTION"):
                     raise ValueError("Missing required slot for Other: OTHER_TARGET_DESCRIPTION")
@@ -228,6 +236,16 @@ class TestSpatial:
                 "HGNC_VERSION": "2025-01-01",
             })
 
+        # Human Gene with ENST-prefixed ID raises error
+        with pytest.raises(ValueError, match="ENSG-prefixed"):
+            validate({
+                "HTAN_PANEL_ID": "HTA201_1_P1",
+                "TARGET_TYPE": "Human Gene",
+                "TARGET_NAME": "MYC",
+                "ENSEMBL_ID": "ENST00000621592",
+                "HGNC_VERSION": "2025-01-01",
+            })
+
         # Human Transcript without HGNC_VERSION is valid
         validate({
             "HTAN_PANEL_ID": "HTA201_1_P1",
@@ -235,6 +253,15 @@ class TestSpatial:
             "TARGET_NAME": "MYC-201",
             "ENSEMBL_ID": "ENST00000621592",
         })
+
+        # Human Transcript with ENSG-prefixed ID raises error
+        with pytest.raises(ValueError, match="ENST-prefixed"):
+            validate({
+                "HTAN_PANEL_ID": "HTA201_1_P1",
+                "TARGET_TYPE": "Human Transcript",
+                "TARGET_NAME": "MYC-201",
+                "ENSEMBL_ID": "ENSG00000136997",
+            })
 
         # Other missing OTHER_TARGET_DESCRIPTION raises error
         with pytest.raises(ValueError, match="OTHER_TARGET_DESCRIPTION"):
@@ -251,6 +278,14 @@ class TestSpatial:
             "TARGET_NAME": "HPV16-E6",
             "OTHER_TARGET_DESCRIPTION": "Human papillomavirus 16 E6 protein",
         })
+
+        # Bacterial, Viral, Control Probe, Human Protein — only TARGET_NAME required
+        for target_type in ["Bacterial", "Viral", "Control Probe", "Human Protein"]:
+            validate({
+                "HTAN_PANEL_ID": "HTA201_1_P1",
+                "TARGET_TYPE": target_type,
+                "TARGET_NAME": "some-target",
+            })
 
         # Invalid TARGET_TYPE raises error
         with pytest.raises(ValueError, match="Invalid TARGET_TYPE"):

--- a/modules/SpatialOmics/tests/test_spatial.py
+++ b/modules/SpatialOmics/tests/test_spatial.py
@@ -204,7 +204,7 @@ class TestSpatial:
                 ensembl_id = data.get("ENSEMBL_ID")
                 if not ensembl_id:
                     raise ValueError("Missing required slot for Human Gene: ENSEMBL_ID")
-                if not re.match(r"^ENSG\d+$", ensembl_id):
+                if not re.match(r"^ENSG\d+(\.\d+)?$", ensembl_id):
                     raise ValueError(f"ENSEMBL_ID must be ENSG-prefixed for Human Gene, got: {ensembl_id!r}")
                 if not data.get("HGNC_VERSION"):
                     raise ValueError("Missing required slot for Human Gene: HGNC_VERSION")
@@ -212,7 +212,7 @@ class TestSpatial:
                 ensembl_id = data.get("ENSEMBL_ID")
                 if not ensembl_id:
                     raise ValueError("Missing required slot for Human Transcript: ENSEMBL_ID")
-                if not re.match(r"^ENST\d+$", ensembl_id):
+                if not re.match(r"^ENST\d+(\.\d+)?$", ensembl_id):
                     raise ValueError(f"ENSEMBL_ID must be ENST-prefixed for Human Transcript, got: {ensembl_id!r}")
             if target_type == "Other":
                 if not data.get("OTHER_TARGET_DESCRIPTION"):
@@ -336,7 +336,7 @@ class TestSpatial:
         # Test Ensembl ID pattern (ENSG for genes, ENST for transcripts)
         ensembl_id_slot = sv.get_slot("ENSEMBL_ID")
         assert ensembl_id_slot is not None
-        assert ensembl_id_slot.pattern == "^(ENSG\\d+|ENST\\d+)$"
+        assert ensembl_id_slot.pattern == "^(ENSG|ENST)\\d+(\\.\\d+)?$"
 
         # Test HGNC Version pattern
         hgnc_version_slot = sv.get_slot("HGNC_VERSION")

--- a/modules/WES/src/htan_wes/datamodel/wes.py
+++ b/modules/WES/src/htan_wes/datamodel/wes.py
@@ -1,5 +1,5 @@
 # Auto generated from wes.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-30T16:46:22
+# Generation date: 2026-04-30T17:14:25
 # Schema: WES
 #
 # id: https://w3id.org/htan/wes

--- a/modules/WES/src/htan_wes/datamodel/wes.py
+++ b/modules/WES/src/htan_wes/datamodel/wes.py
@@ -1,5 +1,5 @@
 # Auto generated from wes.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-01T18:40:23
+# Generation date: 2026-05-01T18:50:32
 # Schema: WES
 #
 # id: https://w3id.org/htan/wes

--- a/modules/WES/src/htan_wes/datamodel/wes.py
+++ b/modules/WES/src/htan_wes/datamodel/wes.py
@@ -1,5 +1,5 @@
 # Auto generated from wes.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-30T17:14:25
+# Generation date: 2026-05-01T16:23:20
 # Schema: WES
 #
 # id: https://w3id.org/htan/wes

--- a/modules/WES/src/htan_wes/datamodel/wes.py
+++ b/modules/WES/src/htan_wes/datamodel/wes.py
@@ -1,5 +1,5 @@
 # Auto generated from wes.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-01T16:39:41
+# Generation date: 2026-05-01T18:40:23
 # Schema: WES
 #
 # id: https://w3id.org/htan/wes

--- a/modules/WES/src/htan_wes/datamodel/wes.py
+++ b/modules/WES/src/htan_wes/datamodel/wes.py
@@ -1,5 +1,5 @@
 # Auto generated from wes.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-29T17:34:18
+# Generation date: 2026-04-30T16:34:51
 # Schema: WES
 #
 # id: https://w3id.org/htan/wes

--- a/modules/WES/src/htan_wes/datamodel/wes.py
+++ b/modules/WES/src/htan_wes/datamodel/wes.py
@@ -1,5 +1,5 @@
 # Auto generated from wes.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-15T14:31:34
+# Generation date: 2026-04-29T17:34:18
 # Schema: WES
 #
 # id: https://w3id.org/htan/wes

--- a/modules/WES/src/htan_wes/datamodel/wes.py
+++ b/modules/WES/src/htan_wes/datamodel/wes.py
@@ -1,5 +1,5 @@
 # Auto generated from wes.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-01T16:23:20
+# Generation date: 2026-05-01T16:39:41
 # Schema: WES
 #
 # id: https://w3id.org/htan/wes

--- a/modules/WES/src/htan_wes/datamodel/wes.py
+++ b/modules/WES/src/htan_wes/datamodel/wes.py
@@ -1,5 +1,5 @@
 # Auto generated from wes.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-30T16:34:51
+# Generation date: 2026-04-30T16:46:22
 # Schema: WES
 #
 # id: https://w3id.org/htan/wes

--- a/modules/scRNA-seq/src/htan_scrna_seq/datamodel/scrna_seq.py
+++ b/modules/scRNA-seq/src/htan_scrna_seq/datamodel/scrna_seq.py
@@ -1,5 +1,5 @@
 # Auto generated from scrna_seq.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-29T17:34:39
+# Generation date: 2026-04-30T16:35:11
 # Schema: scRNA-seq
 #
 # id: https://w3id.org/htan/scrna_seq

--- a/modules/scRNA-seq/src/htan_scrna_seq/datamodel/scrna_seq.py
+++ b/modules/scRNA-seq/src/htan_scrna_seq/datamodel/scrna_seq.py
@@ -1,5 +1,5 @@
 # Auto generated from scrna_seq.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-01T16:40:00
+# Generation date: 2026-05-01T18:40:43
 # Schema: scRNA-seq
 #
 # id: https://w3id.org/htan/scrna_seq

--- a/modules/scRNA-seq/src/htan_scrna_seq/datamodel/scrna_seq.py
+++ b/modules/scRNA-seq/src/htan_scrna_seq/datamodel/scrna_seq.py
@@ -1,5 +1,5 @@
 # Auto generated from scrna_seq.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-01T18:40:43
+# Generation date: 2026-05-01T18:50:51
 # Schema: scRNA-seq
 #
 # id: https://w3id.org/htan/scrna_seq

--- a/modules/scRNA-seq/src/htan_scrna_seq/datamodel/scrna_seq.py
+++ b/modules/scRNA-seq/src/htan_scrna_seq/datamodel/scrna_seq.py
@@ -1,5 +1,5 @@
 # Auto generated from scrna_seq.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-30T16:35:11
+# Generation date: 2026-04-30T16:46:42
 # Schema: scRNA-seq
 #
 # id: https://w3id.org/htan/scrna_seq

--- a/modules/scRNA-seq/src/htan_scrna_seq/datamodel/scrna_seq.py
+++ b/modules/scRNA-seq/src/htan_scrna_seq/datamodel/scrna_seq.py
@@ -1,5 +1,5 @@
 # Auto generated from scrna_seq.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-30T17:14:45
+# Generation date: 2026-05-01T16:23:39
 # Schema: scRNA-seq
 #
 # id: https://w3id.org/htan/scrna_seq

--- a/modules/scRNA-seq/src/htan_scrna_seq/datamodel/scrna_seq.py
+++ b/modules/scRNA-seq/src/htan_scrna_seq/datamodel/scrna_seq.py
@@ -1,5 +1,5 @@
 # Auto generated from scrna_seq.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-15T14:31:53
+# Generation date: 2026-04-29T17:34:39
 # Schema: scRNA-seq
 #
 # id: https://w3id.org/htan/scrna_seq

--- a/modules/scRNA-seq/src/htan_scrna_seq/datamodel/scrna_seq.py
+++ b/modules/scRNA-seq/src/htan_scrna_seq/datamodel/scrna_seq.py
@@ -1,5 +1,5 @@
 # Auto generated from scrna_seq.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-30T16:46:42
+# Generation date: 2026-04-30T17:14:45
 # Schema: scRNA-seq
 #
 # id: https://w3id.org/htan/scrna_seq

--- a/modules/scRNA-seq/src/htan_scrna_seq/datamodel/scrna_seq.py
+++ b/modules/scRNA-seq/src/htan_scrna_seq/datamodel/scrna_seq.py
@@ -1,5 +1,5 @@
 # Auto generated from scrna_seq.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-01T16:23:39
+# Generation date: 2026-05-01T16:40:00
 # Schema: scRNA-seq
 #
 # id: https://w3id.org/htan/scrna_seq


### PR DESCRIPTION
## Summary

- Add `HTAN_PANEL_ID` as a required field to `MultiplexMicroscopyLevel2` and `ChannelMetadata` schemas, enabling panel-level grouping and join keys across RecordSets (fixes #177)
- Add `TARGET_TYPE` enum and conditional field requirements to `SpatialPanel` to support non-human probes (e.g. microbiome, viral targets) that lack Ensembl/HGNC identifiers (fixes #179, closes #175)
- Make `PHYSICAL_SIZE_Z` optional in `MultiplexMicroscopyLevel2`, conditionally required only when `SIZE_Z > 1`, to accommodate 2D acquisitions like CODEX (fixes #174)

## Changes

**`modules/MultiplexMicroscopy/domains/level_2.yaml`**
- Added `HTAN_PANEL_ID` (required, with HTAN P-prefix pattern) before `CHANNEL_METADATA_ID`
- Changed `PHYSICAL_SIZE_Z` from `required: true` to `required: false`; added a `rules` block making it required when `SIZE_Z >= 2`

**`modules/MultiplexMicroscopy/domains/multiplex_microscopy_channel_metadata.yaml`**
- Added `HTAN_PANEL_ID` (required, with HTAN P-prefix pattern) before `CHANNEL_ID`

**`modules/SpatialOmics/domains/spatial_panel.yaml`**
- Added `TargetTypeEnum` with values `Human Gene`, `Human Transcript`, `Other`
- Added required `TARGET_TYPE` slot
- Added `OTHER_TARGET_TYPE` slot (free-text, conditionally required)
- Changed `GENE_SYMBOL`, `HGNC_VERSION`, `GENE_ID` from `required: true` to `required: false`
- Added two `rules` blocks: `GENE_SYMBOL`/`HGNC_VERSION`/`GENE_ID` required when `TARGET_TYPE` is `Human Gene` or `Human Transcript`; `USER_GENE_NAME` and `OTHER_TARGET_TYPE` required when `TARGET_TYPE` is `Other`

## Tests

- Updated `test_spatial_panel_class` to reflect conditional rather than unconditional requirements
- Added `test_physical_size_z_conditional` asserting the rule structure for `PHYSICAL_SIZE_Z`

## Test Plan

- `poetry run pytest modules/MultiplexMicroscopy/` — 17 passed
- `poetry run pytest modules/SpatialOmics/` — 11 passed

> **Note:** Issue #175 is a duplicate of #179 and can be closed without separate changes.