### PR TITLE
Fix fix_boolean_patterns recursion under nested combinators in if (#187)

### DIFF
--- a/scripts/linkml_to_flat_synapse_jsonschema.py
+++ b/scripts/linkml_to_flat_synapse_jsonschema.py
@@ -19,6 +19,7 @@ to const: true or const: false because JSON Schema's pattern keyword only applie
 to strings, not booleans. This ensures conditional requirements work correctly
 for boolean fields in the generated JSON Schema.
 """
+
 from pathlib import Path
 from typing import Any, Union
 import argparse
@@ -275,11 +276,56 @@ def fix_boolean_patterns(schema_data: dict) -> dict:
     - Before: {"HAS_SLIDE_LABEL": {"pattern": "^true$"}}
     - After:  {"HAS_SLIDE_LABEL": {"const": true}}
 
-    Only affects properties with type: "boolean" in the schema.
+    The rewrite is applied to any `properties` map nested anywhere inside an
+    `if` clause, including under `anyOf`, `oneOf`, `allOf`, and `not`. This
+    matters because LinkML emits boolean rules of the form
+    `if: { anyOf: [{properties: {X: {pattern: "^true$"}}}, ...] }`, and the
+    rewrite must descend into those branches — otherwise `pattern` is left in
+    place against a boolean field and silently never matches.
+
+    Only affects properties with type: "boolean" in the top-level schema.
     String fields with patterns are left unchanged.
     """
-    # Get property types from the schema
     properties = schema_data.get("properties", {})
+
+    def rewrite_properties_map(props_map: dict) -> None:
+        """Rewrite pattern -> const for any boolean-typed property in a properties map."""
+        if not isinstance(props_map, dict):
+            return
+        for prop_name, prop_schema in props_map.items():
+            if not isinstance(prop_schema, dict):
+                continue
+            if properties.get(prop_name, {}).get("type") != "boolean":
+                continue
+            pattern = prop_schema.get("pattern")
+            if pattern == "^true$":
+                prop_schema["const"] = True
+                del prop_schema["pattern"]
+            elif pattern == "^false$":
+                prop_schema["const"] = False
+                del prop_schema["pattern"]
+
+    def walk_if_subschema(node, visited):
+        """Walk every subschema reachable inside an `if` clause and rewrite boolean patterns."""
+        node_id = id(node)
+        if node_id in visited:
+            return
+        visited.add(node_id)
+        if isinstance(node, dict):
+            if isinstance(node.get("properties"), dict):
+                rewrite_properties_map(node["properties"])
+            for key in ("anyOf", "oneOf", "allOf"):
+                branches = node.get(key)
+                if isinstance(branches, list):
+                    for item in branches:
+                        walk_if_subschema(item, visited)
+            for key in ("not", "if", "then", "else"):
+                child = node.get(key)
+                if isinstance(child, dict):
+                    walk_if_subschema(child, visited)
+        elif isinstance(node, list):
+            for item in node:
+                walk_if_subschema(item, visited)
 
     def fix_boolean_patterns_in_obj(obj, visited=None):
         if visited is None:
@@ -292,30 +338,13 @@ def fix_boolean_patterns(schema_data: dict) -> dict:
 
         try:
             if isinstance(obj, dict):
-                # Check if this is an "if" clause with properties
-                if "if" in obj and isinstance(obj["if"], dict):
-                    if_clause = obj["if"]
-                    if "properties" in if_clause:
-                        for prop_name, prop_schema in if_clause["properties"].items():
-                            # Check if this property is a boolean type
-                            prop_def = properties.get(prop_name, {})
-                            if prop_def.get("type") == "boolean":
-                                # Convert pattern to const for boolean fields
-                                if "pattern" in prop_schema:
-                                    pattern = prop_schema["pattern"]
-                                    if pattern == "^true$":
-                                        prop_schema["const"] = True
-                                        del prop_schema["pattern"]
-                                    elif pattern == "^false$":
-                                        prop_schema["const"] = False
-                                        del prop_schema["pattern"]
+                if isinstance(obj.get("if"), dict):
+                    walk_if_subschema(obj["if"], set())
 
-                # Recursively process allOf arrays (where rules are typically stored)
-                if "allOf" in obj and isinstance(obj["allOf"], list):
+                if isinstance(obj.get("allOf"), list):
                     for item in obj["allOf"]:
                         fix_boolean_patterns_in_obj(item, visited)
 
-                # Recursively process nested objects
                 for value in obj.values():
                     fix_boolean_patterns_in_obj(value, visited)
             elif isinstance(obj, list):

--- a/tests/test_linkml_schema_conversion.py
+++ b/tests/test_linkml_schema_conversion.py
@@ -16,6 +16,7 @@ from scripts.linkml_to_flat_synapse_jsonschema import (
     _fix_schema_version_logic,
     remove_unsupported_fields,
     fix_additional_properties,
+    fix_boolean_patterns,
 )
 
 
@@ -360,6 +361,123 @@ class TestRunGenJsonSchema:
             assert mock_instance.top_class == "TestClass"
         finally:
             Path(temp_file).unlink()
+
+
+class TestFixBooleanPatterns:
+    """Test boolean pattern -> const rewriting under `if` clauses."""
+
+    def _schema_with_if(self, if_clause):
+        return {
+            "type": "object",
+            "properties": {
+                "RNA_MEASURED": {"type": "boolean"},
+                "PROTEIN_MEASURED": {"type": "boolean"},
+                "TRANSCRIPTOME_TYPE": {"type": "string"},
+                "PANEL_NAME": {"type": "string"},
+            },
+            "allOf": [
+                {
+                    "if": if_clause,
+                    "then": {"required": ["PANEL_NAME"]},
+                }
+            ],
+        }
+
+    def test_direct_if_properties_boolean_true(self):
+        """pattern: ^true$ on a boolean field directly under if.properties is rewritten to const: True."""
+        schema = self._schema_with_if(
+            {
+                "properties": {"RNA_MEASURED": {"pattern": "^true$"}},
+                "required": ["RNA_MEASURED"],
+            }
+        )
+        result = fix_boolean_patterns(schema)
+        rule = result["allOf"][0]["if"]["properties"]["RNA_MEASURED"]
+        assert rule == {"const": True}
+
+    def test_direct_if_properties_boolean_false(self):
+        """pattern: ^false$ on a boolean field is rewritten to const: False."""
+        schema = self._schema_with_if(
+            {
+                "properties": {"RNA_MEASURED": {"pattern": "^false$"}},
+                "required": ["RNA_MEASURED"],
+            }
+        )
+        result = fix_boolean_patterns(schema)
+        rule = result["allOf"][0]["if"]["properties"]["RNA_MEASURED"]
+        assert rule == {"const": False}
+
+    def test_anyof_inside_if_rewrites_nested_boolean_pattern(self):
+        """pattern: ^true$ on a boolean field nested under if.anyOf[].properties is rewritten."""
+        schema = self._schema_with_if(
+            {
+                "anyOf": [
+                    {
+                        "properties": {"TRANSCRIPTOME_TYPE": {"const": "Targeted"}},
+                        "required": ["TRANSCRIPTOME_TYPE"],
+                    },
+                    {
+                        "properties": {"PROTEIN_MEASURED": {"pattern": "^true$"}},
+                        "required": ["PROTEIN_MEASURED"],
+                    },
+                ]
+            }
+        )
+        result = fix_boolean_patterns(schema)
+        anyof = result["allOf"][0]["if"]["anyOf"]
+        # String const branch is untouched
+        assert anyof[0]["properties"]["TRANSCRIPTOME_TYPE"] == {"const": "Targeted"}
+        # Boolean pattern branch is rewritten
+        assert anyof[1]["properties"]["PROTEIN_MEASURED"] == {"const": True}
+
+    def test_oneof_inside_if_rewrites_nested_boolean_pattern(self):
+        """oneOf branches inside if are also rewritten."""
+        schema = self._schema_with_if(
+            {
+                "oneOf": [
+                    {
+                        "properties": {"RNA_MEASURED": {"pattern": "^true$"}},
+                        "required": ["RNA_MEASURED"],
+                    },
+                ]
+            }
+        )
+        result = fix_boolean_patterns(schema)
+        assert result["allOf"][0]["if"]["oneOf"][0]["properties"]["RNA_MEASURED"] == {
+            "const": True
+        }
+
+    def test_not_inside_if_rewrites_nested_boolean_pattern(self):
+        """`not` branch inside if is rewritten."""
+        schema = self._schema_with_if(
+            {
+                "not": {
+                    "properties": {"RNA_MEASURED": {"pattern": "^false$"}},
+                    "required": ["RNA_MEASURED"],
+                }
+            }
+        )
+        result = fix_boolean_patterns(schema)
+        assert result["allOf"][0]["if"]["not"]["properties"]["RNA_MEASURED"] == {
+            "const": False
+        }
+
+    def test_string_pattern_under_anyof_left_alone(self):
+        """Patterns on non-boolean fields are not touched, even under anyOf inside if."""
+        schema = self._schema_with_if(
+            {
+                "anyOf": [
+                    {
+                        "properties": {"TRANSCRIPTOME_TYPE": {"pattern": "^Targeted$"}},
+                        "required": ["TRANSCRIPTOME_TYPE"],
+                    },
+                ]
+            }
+        )
+        result = fix_boolean_patterns(schema)
+        assert result["allOf"][0]["if"]["anyOf"][0]["properties"][
+            "TRANSCRIPTOME_TYPE"
+        ] == {"pattern": "^Targeted$"}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- `scripts/linkml_to_flat_synapse_jsonschema.py::fix_boolean_patterns()` only rewrote `pattern: "^true$"` → `const: true` when the `if` clause had `properties` directly. It did **not** descend into `if.anyOf[]`, `if.oneOf[]`, `if.allOf[]`, or `if.not` — so LinkML rules emitted as `if: { anyOf: [...] }` shipped with `pattern: "^true$"` against boolean fields. `pattern` is a string-only keyword, so those branches silently never matched and the conditional `required` never fired (e.g. `PANEL_NAME` was not enforced when `PROTEIN_MEASURED: true`).
- Extends the walk so every subschema reachable inside an `if` clause is visited (anyOf, oneOf, allOf, not, and nested if/then/else), applying the same boolean-pattern → const rewrite wherever a `properties` map is found.
- Adds six unit tests covering direct `if.properties`, `if.anyOf`, `if.oneOf`, `if.not`, true/false variants, and a regression test confirming string-typed patterns are left alone.

Fixes #187.

## Test plan

- [x] `PYTHONPATH=. python -m pytest tests/test_linkml_schema_conversion.py -v` → 22 passed (16 existing + 6 new)
- [x] Black-formatted with the project's existing style
- [ ] Downstream regen: after merge, regenerating `JSON_Schemas/v1.5.0/HTAN.SpatialLevel3-v1.5.0-schema.json` should now show `"const": true` inside the `if.anyOf[]` branches for `PROTEIN_MEASURED` instead of `"pattern": "^true$"`. Per CLAUDE.md, that regen lands in a separate downstream PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)