### PR TITLE
Therapy rules flagging wrong fields as required

### DIFF
--- a/modules/Biospecimen/src/htan_biospecimen/datamodel/biospecimen.py
+++ b/modules/Biospecimen/src/htan_biospecimen/datamodel/biospecimen.py
@@ -1,5 +1,5 @@
 # Auto generated from biospecimen.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-01T18:50:34
+# Generation date: 2026-05-18T06:09:29
 # Schema: Biospecimen
 #
 # id: https://w3id.org/htan/biospecimen

--- a/modules/Clinical/domains/therapy.yaml
+++ b/modules/Clinical/domains/therapy.yaml
@@ -278,8 +278,18 @@ classes:
           slot_conditions:
             TREATMENT_TYPE:
               any_of:
-                - pattern: ".*Surgical.*"
-                - pattern: ".*Radiation.*"
+                - has_member:
+                    equals_string: "Surgical Procedure"
+                - has_member:
+                    equals_string_in:
+                      - "3-Dimensional Conformal Radiation Therapy"
+                      - "Electron Beam Radiation Therapy"
+                      - "External Beam Radiation Therapy"
+                      - "Intensity-Modulated Radiation Therapy"
+                      - "Photon Beam Radiation Therapy"
+                      - "Proton Beam Radiation Therapy"
+                      - "Radiation Therapy"
+                      - "Stereotactic Body Radiation Therapy"
         postconditions:
           slot_conditions:
             THERAPY_ANATOMIC_SITE_UBERON_CODE:
@@ -299,9 +309,10 @@ classes:
         preconditions:
           slot_conditions:
             TREATMENT_TYPE:
-              any_of:
-                - pattern: ".*Chemotherapy.*"
-                - pattern: ".*Concurrent Chemoradiation.*"
+              has_member:
+                equals_string_in:
+                  - "Chemotherapy"
+                  - "Concurrent Chemoradiation"
         postconditions:
           slot_conditions:
             THERAPEUTIC_AGENTS:
@@ -312,8 +323,8 @@ classes:
         preconditions:
           slot_conditions:
             TREATMENT_TYPE:
-              any_of:
-                - pattern: ".*Pharmacotherapy.*"
+              has_member:
+                equals_string: "Pharmacotherapy"
         postconditions:
           slot_conditions:
             THERAPEUTIC_AGENTS:

--- a/modules/Clinical/src/htan_clinical/datamodel/clinical.py
+++ b/modules/Clinical/src/htan_clinical/datamodel/clinical.py
@@ -1,5 +1,5 @@
 # Auto generated from clinical.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-01T18:47:53
+# Generation date: 2026-05-18T06:06:26
 # Schema: Clinical
 #
 # id: https://w3id.org/htan/clinical

--- a/modules/DigitalPathology/src/htan_digitalpathology/datamodel/digital_pathology.py
+++ b/modules/DigitalPathology/src/htan_digitalpathology/datamodel/digital_pathology.py
@@ -1,5 +1,5 @@
 # Auto generated from digital_pathology.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-01T18:50:53
+# Generation date: 2026-05-18T06:09:49
 # Schema: DigitalPathology
 #
 # id: https://w3id.org/htan/digital_pathology

--- a/modules/Imaging/src/htan_imaging/datamodel/imaging.py
+++ b/modules/Imaging/src/htan_imaging/datamodel/imaging.py
@@ -1,5 +1,5 @@
 # Auto generated from imaging.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-01T18:50:50
+# Generation date: 2026-05-18T06:09:46
 # Schema: Imaging
 #
 # id: https://w3id.org/htan/imaging

--- a/modules/MultiplexMicroscopy/src/htan_multiplexmicroscopy/datamodel/multiplex_microscopy.py
+++ b/modules/MultiplexMicroscopy/src/htan_multiplexmicroscopy/datamodel/multiplex_microscopy.py
@@ -1,5 +1,5 @@
 # Auto generated from multiplex_microscopy.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-01T18:50:54
+# Generation date: 2026-05-18T06:09:51
 # Schema: MultiplexMicroscopy
 #
 # id: https://w3id.org/htan/multiplex_microscopy

--- a/modules/Sequencing/src/htan_sequencing/datamodel/sequencing.py
+++ b/modules/Sequencing/src/htan_sequencing/datamodel/sequencing.py
@@ -1,5 +1,5 @@
 # Auto generated from sequencing.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-01T18:50:48
+# Generation date: 2026-05-18T06:09:44
 # Schema: Sequencing
 #
 # id: https://w3id.org/htan/sequencing

--- a/modules/SpatialOmics/src/htan_spatial/datamodel/spatial.py
+++ b/modules/SpatialOmics/src/htan_spatial/datamodel/spatial.py
@@ -1,5 +1,5 @@
 # Auto generated from spatial.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-01T18:50:56
+# Generation date: 2026-05-18T06:09:52
 # Schema: SpatialOmics
 #
 # id: https://w3id.org/htan/spatial

--- a/modules/WES/src/htan_wes/datamodel/wes.py
+++ b/modules/WES/src/htan_wes/datamodel/wes.py
@@ -1,5 +1,5 @@
 # Auto generated from wes.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-01T18:50:32
+# Generation date: 2026-05-18T06:09:27
 # Schema: WES
 #
 # id: https://w3id.org/htan/wes

--- a/modules/scRNA-seq/src/htan_scrna_seq/datamodel/scrna_seq.py
+++ b/modules/scRNA-seq/src/htan_scrna_seq/datamodel/scrna_seq.py
@@ -1,5 +1,5 @@
 # Auto generated from scrna_seq.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-01T18:50:51
+# Generation date: 2026-05-18T06:09:47
 # Schema: scRNA-seq
 #
 # id: https://w3id.org/htan/scrna_seq

--- a/scripts/linkml_to_flat_synapse_jsonschema.py
+++ b/scripts/linkml_to_flat_synapse_jsonschema.py
@@ -330,6 +330,129 @@ def fix_boolean_patterns(schema_data: dict) -> dict:
     return schema_data
 
 
+def _build_contains_from_anon_slot(anon_slot) -> Union[dict, None]:
+    """Translate a LinkML AnonymousSlotExpression into a JSON Schema fragment
+    expressing "the multivalued slot contains a member matching this constraint."
+
+    Handles two shapes that appear in HTAN rule preconditions:
+    - Direct: ``has_member: { equals_string: "X" }`` -> ``{contains: {const: "X"}}``
+    - any_of of branches, each carrying a ``has_member`` block
+      -> ``{anyOf: [{contains: ...}, ...]}``
+
+    Returns None when the slot expression has no translatable member constraint
+    so the caller can leave the existing JSON fragment untouched.
+    """
+    if anon_slot is None:
+        return None
+
+    any_of = getattr(anon_slot, "any_of", None)
+    if any_of:
+        branches = []
+        for sub in any_of:
+            sub_fragment = _build_contains_from_anon_slot(sub)
+            if sub_fragment:
+                branches.append(sub_fragment)
+        if branches:
+            return {"anyOf": branches}
+        return None
+
+    has_member = getattr(anon_slot, "has_member", None)
+    if not has_member:
+        return None
+
+    contains: dict = {}
+    if getattr(has_member, "equals_string", None):
+        contains["const"] = has_member.equals_string
+    elif getattr(has_member, "equals_string_in", None):
+        contains["enum"] = list(has_member.equals_string_in)
+    elif getattr(has_member, "pattern", None):
+        contains["pattern"] = has_member.pattern
+    else:
+        return None
+    return {"contains": contains}
+
+
+def fix_multivalued_member_constraints(
+    schema_data: dict, linkml_yaml: str, class_name: str
+) -> dict:
+    """Rewrite rule preconditions on multivalued slots to use JSON Schema ``contains``.
+
+    LinkML's ``JsonSchemaGenerator`` processes rule preconditions with
+    ``omit_type=True``, which short-circuits the array-aware code path that
+    translates ``has_member`` into ``contains``. The result is an empty ``{}``
+    constraint on the multivalued slot inside the ``if`` clause, which means the
+    ``if`` is vacuously satisfied for every record and the ``then`` requirements
+    fire unconditionally (HTAN-859).
+
+    This function walks the source LinkML schema to recover the original
+    ``has_member`` expressions for each rule's precondition slots and replaces
+    the empty fragments in the generated JSON with proper ``contains`` clauses.
+    Matching is positional: rules from the class and its ancestors are zipped
+    against the JSON output's ``allOf`` (or top-level ``if``), mirroring how
+    ``JsonSchemaGenerator`` emits them.
+
+    Only runs when ``class_name`` is set so the SchemaView can resolve which
+    slots are multivalued in the context of the target class.
+    """
+    if not class_name:
+        return schema_data
+
+    sv = SchemaView(linkml_yaml)
+    try:
+        ancestor_names = sv.class_ancestors(class_name)
+    except Exception:
+        return schema_data
+
+    rules = []
+    for ancestor_name in ancestor_names:
+        cls = sv.get_class(ancestor_name)
+        if cls and getattr(cls, "rules", None):
+            rules.extend(cls.rules)
+
+    if not rules:
+        return schema_data
+
+    if_then_blocks: list[dict] = []
+    if isinstance(schema_data.get("allOf"), list):
+        if_then_blocks = [item for item in schema_data["allOf"] if isinstance(item, dict) and "if" in item]
+    elif "if" in schema_data:
+        if_then_blocks = [schema_data]
+
+    if len(rules) != len(if_then_blocks):
+        print(
+            f"Warning: rule count ({len(rules)}) does not match if/then block count "
+            f"({len(if_then_blocks)}); skipping multivalued precondition fix"
+        )
+        return schema_data
+
+    fixed = 0
+    for rule, block in zip(rules, if_then_blocks):
+        preconditions = getattr(rule, "preconditions", None)
+        if not preconditions:
+            continue
+        slot_conditions = getattr(preconditions, "slot_conditions", None) or {}
+        if_props = block.get("if", {}).get("properties", {})
+        for slot_name, anon_slot in slot_conditions.items():
+            if slot_name not in if_props:
+                continue
+            try:
+                induced = sv.induced_slot(slot_name, class_name)
+            except Exception:
+                continue
+            if not getattr(induced, "multivalued", False):
+                continue
+            replacement = _build_contains_from_anon_slot(anon_slot)
+            if not replacement:
+                continue
+            if_props[slot_name].clear()
+            if_props[slot_name].update(replacement)
+            fixed += 1
+
+    if fixed:
+        print(f"Fixed {fixed} multivalued precondition constraint(s) using `contains`")
+    return schema_data
+
+
 def backfill_descriptions_from_linkml(
     schema_data: dict, linkml_yaml: str, class_name: str
 ) -> dict:
@@ -431,6 +554,9 @@ def main():
     schema_data = fix_additional_properties(schema_data)
     schema_data = clean_union_types(schema_data)
     schema_data = fix_boolean_patterns(schema_data)
+    schema_data = fix_multivalued_member_constraints(
+        schema_data, args.linkml_yaml, args.class_name
+    )
     schema_data = remove_unsupported_fields(schema_data)
 
     # 4. Write final result to output file

--- a/tests/test_linkml_schema_conversion.py
+++ b/tests/test_linkml_schema_conversion.py
@@ -16,6 +16,7 @@ from scripts.linkml_to_flat_synapse_jsonschema import (
     _fix_schema_version_logic,
     remove_unsupported_fields,
     fix_additional_properties,
+    fix_multivalued_member_constraints,
 )
 
 
@@ -360,6 +361,214 @@ class TestRunGenJsonSchema:
             assert mock_instance.top_class == "TestClass"
         finally:
             Path(temp_file).unlink()
+
+
+class TestFixMultivaluedMemberConstraints:
+    """Tests for the rule-precondition rewrite that translates LinkML ``has_member``
+    on multivalued slots into JSON Schema ``contains``.
+
+    Each test writes a tiny LinkML schema to a temp file, hand-builds the empty
+    if/then JSON that LinkML emits for rule preconditions on multivalued slots,
+    runs the post-processor, and asserts the rewrite.
+    """
+
+    @staticmethod
+    def _write_schema(yaml_text: str) -> str:
+        tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False)
+        tmp.write(yaml_text)
+        tmp.close()
+        return tmp.name
+
+    def test_equals_string_rewrites_to_contains_const(self):
+        yaml_text = """
+id: https://example.org/test
+name: test
+prefixes:
+  linkml: https://w3id.org/linkml/
+imports:
+  - linkml:types
+default_range: string
+classes:
+  Sample:
+    attributes:
+      KIND:
+        multivalued: true
+        required: true
+      TARGET:
+        required: false
+    rules:
+      - preconditions:
+          slot_conditions:
+            KIND:
+              has_member:
+                equals_string: "Pharmacotherapy"
+        postconditions:
+          slot_conditions:
+            TARGET:
+              required: true
+"""
+        yaml_path = self._write_schema(yaml_text)
+        try:
+            schema_data = {
+                "if": {
+                    "properties": {"KIND": {}},
+                    "required": ["KIND"],
+                },
+                "then": {"required": ["TARGET"]},
+            }
+            fix_multivalued_member_constraints(schema_data, yaml_path, "Sample")
+            assert schema_data["if"]["properties"]["KIND"] == {
+                "contains": {"const": "Pharmacotherapy"}
+            }
+        finally:
+            Path(yaml_path).unlink()
+
+    def test_equals_string_in_rewrites_to_contains_enum(self):
+        yaml_text = """
+id: https://example.org/test
+name: test
+prefixes:
+  linkml: https://w3id.org/linkml/
+imports:
+  - linkml:types
+default_range: string
+classes:
+  Sample:
+    attributes:
+      KIND:
+        multivalued: true
+        required: true
+      TARGET:
+        required: false
+    rules:
+      - preconditions:
+          slot_conditions:
+            KIND:
+              has_member:
+                equals_string_in:
+                  - "Chemotherapy"
+                  - "Concurrent Chemoradiation"
+        postconditions:
+          slot_conditions:
+            TARGET:
+              required: true
+"""
+        yaml_path = self._write_schema(yaml_text)
+        try:
+            schema_data = {
+                "allOf": [
+                    {
+                        "if": {
+                            "properties": {"KIND": {}},
+                            "required": ["KIND"],
+                        },
+                        "then": {"required": ["TARGET"]},
+                    }
+                ]
+            }
+            fix_multivalued_member_constraints(schema_data, yaml_path, "Sample")
+            assert schema_data["allOf"][0]["if"]["properties"]["KIND"] == {
+                "contains": {"enum": ["Chemotherapy", "Concurrent Chemoradiation"]}
+            }
+        finally:
+            Path(yaml_path).unlink()
+
+    def test_any_of_has_member_rewrites_to_anyof_contains(self):
+        yaml_text = """
+id: https://example.org/test
+name: test
+prefixes:
+  linkml: https://w3id.org/linkml/
+imports:
+  - linkml:types
+default_range: string
+classes:
+  Sample:
+    attributes:
+      KIND:
+        multivalued: true
+        required: true
+      TARGET:
+        required: false
+    rules:
+      - preconditions:
+          slot_conditions:
+            KIND:
+              any_of:
+                - has_member:
+                    equals_string: "A"
+                - has_member:
+                    equals_string: "B"
+        postconditions:
+          slot_conditions:
+            TARGET:
+              required: true
+"""
+        yaml_path = self._write_schema(yaml_text)
+        try:
+            schema_data = {
+                "if": {
+                    "properties": {"KIND": {"anyOf": [{}, {}]}},
+                    "required": ["KIND"],
+                },
+                "then": {"required": ["TARGET"]},
+            }
+            fix_multivalued_member_constraints(schema_data, yaml_path, "Sample")
+            assert schema_data["if"]["properties"]["KIND"] == {
+                "anyOf": [
+                    {"contains": {"const": "A"}},
+                    {"contains": {"const": "B"}},
+                ]
+            }
+        finally:
+            Path(yaml_path).unlink()
+
+    def test_scalar_slot_left_unchanged(self):
+        yaml_text = """
+id: https://example.org/test
+name: test
+prefixes:
+  linkml: https://w3id.org/linkml/
+imports:
+  - linkml:types
+default_range: string
+classes:
+  Sample:
+    attributes:
+      KIND:
+        required: true
+      TARGET:
+        required: false
+    rules:
+      - preconditions:
+          slot_conditions:
+            KIND:
+              equals_string: "X"
+        postconditions:
+          slot_conditions:
+            TARGET:
+              required: true
+"""
+        yaml_path = self._write_schema(yaml_text)
+        try:
+            schema_data = {
+                "if": {
+                    "properties": {"KIND": {"const": "X"}},
+                    "required": ["KIND"],
+                },
+                "then": {"required": ["TARGET"]},
+            }
+            original = json.loads(json.dumps(schema_data))
+            fix_multivalued_member_constraints(schema_data, yaml_path, "Sample")
+            assert schema_data == original
+        finally:
+            Path(yaml_path).unlink()
+
+    def test_missing_class_name_skips(self):
+        schema_data = {"if": {"properties": {"KIND": {}}}}
+        original = json.loads(json.dumps(schema_data))
+        fix_multivalued_member_constraints(schema_data, "ignored.yaml", "")
+        assert schema_data == original
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### **Problem**
Therapy records were being flagged for THERAPEUTIC_AGENTS, NUMBER_OF_CYCLES, and REGIMEN_OR_LINE_OF_THERAPY even when treatment was Surgical Procedure only. The rules were firing for every record regardless of treatment type.

### **Why**
The YAML used pattern: ".*Pharmacotherapy.*" against TREATMENT_TYPE, which is a multivalued (array) field. JSON Schema's pattern keyword is string-only — when applied to an array, it vacuously passes. So the if clause was always satisfied and the then requirements always fired.

### **Fix**
Two layers:

1. YAML (therapy.yaml)— switched from pattern to LinkML's has_member + equals_string / equals_string_in, which is the semantically correct way to express "this array contains value X".
2. Converter (scripts/linkml_to_flat_synapse_jsonschema.py) — added fix_multivalued_member_constraints() post-processor. LinkML's stock JSON Schema generator drops has_member constraints inside rule preconditions (known gap), so this walks the output and rewrites them into contains: {const|enum: ...} using the source schema as a lookup.

### **Verified**

- [x] 5 new unit tests in (test_linkml_schema_conversion.py), all passing
- [x] End-to-end tested in Synapse against bound schema HTAN2Organization-Therapy-0.0.999 on folder syn75075405 (test project htan2-testing1). All 13 test cases behave as expected — surgical-only and mixed Surgical+Pharma records now pass without spurious required-field flags.

### **Notes for reviewers**

- For the new JSON Schema, look at and test syn75075405
- The Surgical/Radiation rule (rule 1) now explicitly enumerates radiation enum values. The original pattern: ".*Radiation.*" regex matched the same set, but worth a glance to confirm the enumeration matches curator intent.
- Related but separate: PR #188 fixes the equivalent bug for boolean slots (SpatialLevel3 PANEL_ID/PANEL_NAME). This PR fixes only the multivalued-array variantProblem
- Therapy records were being flagged for THERAPEUTIC_AGENTS, NUMBER_OF_CYCLES, and REGIMEN_OR_LINE_OF_THERAPY even when treatment was Surgical Procedure only. The rules were firing for every record regardless of treatment type.

Fixes #171