### PR TITLE
feat(MSI): add MassSpectrometryImaging module

### DIFF
--- a/.github/workflows/generate-python-classes.yml
+++ b/.github/workflows/generate-python-classes.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
     inputs:
       modules:
-        description: 'Modules to regenerate (comma-separated: biospecimen,clinical,wes,sequencing,imaging,scrna-seq,digitalpathology,multiplexmicroscopy,spatialomics,all). Leave empty or "all" to generate all modules.'
+        description: 'Modules to regenerate (comma-separated: biospecimen,clinical,wes,sequencing,imaging,scrna-seq,digitalpathology,multiplexmicroscopy,spatialomics,massspectrometryimaging,all). Leave empty or "all" to generate all modules.'
         required: false
         default: 'all'
         type: choice
@@ -30,6 +30,7 @@ on:
           - digitalpathology
           - multiplexmicroscopy
           - spatialomics
+          - massspectrometryimaging
           - biospecimen,clinical
           - biospecimen,wes
           - clinical,wes
@@ -229,7 +230,20 @@ jobs:
         else
           echo "⏭️ Skipping SpatialOmics (not in selected modules)"
         fi
-    
+
+    - name: Generate Python Classes for MassSpectrometryImaging
+      if: steps.set-modules.outputs.modules != 'all'
+      run: |
+        MODULES="${{ steps.set-modules.outputs.modules }}"
+        if echo "$MODULES" | grep -q "massspectrometryimaging"; then
+          echo "🔄 Generating Python classes for MassSpectrometryImaging module..."
+          cd modules/MassSpectrometryImaging
+          make gen-schema
+          echo "✅ MassSpectrometryImaging Python classes generated"
+        else
+          echo "⏭️ Skipping MassSpectrometryImaging (not in selected modules)"
+        fi
+
     - name: Check for Changes
       if: steps.run-tests.outcome == 'success' || (github.event_name == 'pull_request' && steps.run-tests.outcome == 'skipped')
       id: check-changes

--- a/.github/workflows/json-schema-synapse.yml
+++ b/.github/workflows/json-schema-synapse.yml
@@ -217,7 +217,38 @@ jobs:
           "modules/DigitalPathology/domains/digital_pathology.yaml" \
           --class-name "DigitalPathologyData" \
           --output "JSON_Schemas/${{ steps.version.outputs.version }}/HTAN.DigitalPathologyData-${{ steps.version.outputs.version }}-schema.json"
-    
+
+        # MassSpectrometryImaging Level 1
+        echo "Generating MassSpectrometryImaging schemas..."
+        poetry run python scripts/linkml_to_flat_synapse_jsonschema.py \
+          "modules/MassSpectrometryImaging/domains/level_1.yaml" \
+          --class-name "MassSpectrometryImagingLevel1" \
+          --output "JSON_Schemas/${{ steps.version.outputs.version }}/HTAN.MassSpectrometryImagingLevel1-${{ steps.version.outputs.version }}-schema.json"
+
+        # MassSpectrometryImaging Level 2
+        poetry run python scripts/linkml_to_flat_synapse_jsonschema.py \
+          "modules/MassSpectrometryImaging/domains/level_2.yaml" \
+          --class-name "MassSpectrometryImagingLevel2" \
+          --output "JSON_Schemas/${{ steps.version.outputs.version }}/HTAN.MassSpectrometryImagingLevel2-${{ steps.version.outputs.version }}-schema.json"
+
+        # MassSpectrometryImaging Level 3
+        poetry run python scripts/linkml_to_flat_synapse_jsonschema.py \
+          "modules/MassSpectrometryImaging/domains/level_3.yaml" \
+          --class-name "MassSpectrometryImagingLevel3" \
+          --output "JSON_Schemas/${{ steps.version.outputs.version }}/HTAN.MassSpectrometryImagingLevel3-${{ steps.version.outputs.version }}-schema.json"
+
+        # MassSpectrometryImaging Level 4
+        poetry run python scripts/linkml_to_flat_synapse_jsonschema.py \
+          "modules/MassSpectrometryImaging/domains/level_4.yaml" \
+          --class-name "MassSpectrometryImagingLevel4" \
+          --output "JSON_Schemas/${{ steps.version.outputs.version }}/HTAN.MassSpectrometryImagingLevel4-${{ steps.version.outputs.version }}-schema.json"
+
+        # MassSpectrometryImaging Molecular Assignments RecordSet
+        poetry run python scripts/linkml_to_flat_synapse_jsonschema.py \
+          "modules/MassSpectrometryImaging/domains/molecular_assignments.yaml" \
+          --class-name "MolecularAssignment" \
+          --output "JSON_Schemas/${{ steps.version.outputs.version }}/HTAN.MolecularAssignment-${{ steps.version.outputs.version }}-schema.json"
+
     - name: Register schemas in Synapse
       env:
         SYNAPSE_USERNAME: ${{ secrets.SYNAPSE_USERNAME }}

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ SOURCE_SCHEMA_PATH = modules/Clinical/domains/clinical.yaml
 GEN_DOC_ARGS = --no-mergeimports
 
 # List of modules (add new modules here)
-MODULES = Clinical WES CoreFile Biospecimen Sequencing Imaging scRNA-seq DigitalPathology MultiplexMicroscopy SpatialOmics
+MODULES = Clinical WES CoreFile Biospecimen Sequencing Imaging scRNA-seq DigitalPathology MultiplexMicroscopy SpatialOmics MassSpectrometryImaging
 
 .PHONY: all clean setup gen-project gendoc git-init-add git-init git-add git-commit git-status help install test modules-gen modules-test format
 
@@ -102,6 +102,7 @@ format:
 		modules/DigitalPathology/tests/ \
 		modules/MultiplexMicroscopy/tests/ \
 		modules/SpatialOmics/tests/ \
+		modules/MassSpectrometryImaging/tests/ \
 		modules/*/src/
 
 # ---

--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ The diagram above illustrates the separation between **Record-Based Modules** (C
 - **Structure**: Four data levels (Level 1: raw data bundle optional, Level 3: processed bundle required, Level 4: interoperable file optional, Panel: panel information)
 - **Features**: Platform flexibility, bundle-level metadata, panel information, QC metrics, conditional requirements
 
+### **Mass Spectrometry Imaging Module**
+- **Purpose**: Spatial mass spectrometry imaging (MALDI, DESI, SIMS, etc.) for label-free detection of lipids, metabolites, peptides, and proteins
+- **Location**: `modules/MassSpectrometryImaging/`
+- **Structure**: Four data levels (Level 1: continuous imzML, Level 2: centroided imzML, Level 3: annotation-filtered OME-TIFF, Level 4: segmentation optional) plus a Molecular Assignments RecordSet
+- **Features**: Inherits from CoreFileAttributes, MALDI-conditional matrix attributes, multivalued analyte class, confidence-level-gated molecular annotations, HuBMAP crosswalk
+
 ## 📁 Project Structure
 
 ```
@@ -97,7 +103,8 @@ htan2-data-model/
 │   ├── scRNA-seq/             # Single-cell RNA sequencing
 │   ├── DigitalPathology/      # Digital Pathology imaging
 │   ├── MultiplexMicroscopy/   # Multiplex Microscopy imaging
-│   └── SpatialOmics/          # Spatial Omics assays
+│   ├── SpatialOmics/          # Spatial Omics assays
+│   └── MassSpectrometryImaging/ # Mass Spectrometry Imaging (MSI)
 ├── config/                    # LinkML configuration
 ├── scripts/                   # Utility scripts
 ├── tests/                     # Root-level tests
@@ -164,6 +171,7 @@ Each module contains detailed documentation:
 - **Digital Pathology Module**: See `modules/DigitalPathology/README.md` for digital pathology imaging
 - **Multiplex Microscopy Module**: See `modules/MultiplexMicroscopy/README.md` for multiplex microscopy imaging
 - **Spatial Omics Module**: See `modules/SpatialOmics/README.md` for spatial omics assays
+- **Mass Spectrometry Imaging Module**: See `modules/MassSpectrometryImaging/README.md` for mass spectrometry imaging
 
 ## 🤝 Contributing
 

--- a/modules/Clinical/src/htan_clinical/datamodel/clinical.py
+++ b/modules/Clinical/src/htan_clinical/datamodel/clinical.py
@@ -1,5 +1,5 @@
 # Auto generated from clinical.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-11T19:51:48
+# Generation date: 2026-07-01T14:20:44
 # Schema: Clinical
 #
 # id: https://w3id.org/htan/clinical

--- a/modules/Clinical/src/htan_clinical/datamodel/clinical.py
+++ b/modules/Clinical/src/htan_clinical/datamodel/clinical.py
@@ -1,5 +1,5 @@
 # Auto generated from clinical.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-07-01T14:20:44
+# Generation date: 2026-07-01T14:36:46
 # Schema: Clinical
 #
 # id: https://w3id.org/htan/clinical

--- a/modules/DigitalPathology/src/htan_digitalpathology/datamodel/digital_pathology.py
+++ b/modules/DigitalPathology/src/htan_digitalpathology/datamodel/digital_pathology.py
@@ -1,5 +1,5 @@
 # Auto generated from digital_pathology.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-07-01T14:24:35
+# Generation date: 2026-07-01T14:40:45
 # Schema: DigitalPathology
 #
 # id: https://w3id.org/htan/digital_pathology

--- a/modules/DigitalPathology/src/htan_digitalpathology/datamodel/digital_pathology.py
+++ b/modules/DigitalPathology/src/htan_digitalpathology/datamodel/digital_pathology.py
@@ -1,5 +1,5 @@
 # Auto generated from digital_pathology.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-11T19:56:05
+# Generation date: 2026-07-01T14:24:35
 # Schema: DigitalPathology
 #
 # id: https://w3id.org/htan/digital_pathology

--- a/modules/Imaging/src/htan_imaging/datamodel/imaging.py
+++ b/modules/Imaging/src/htan_imaging/datamodel/imaging.py
@@ -1,5 +1,5 @@
 # Auto generated from imaging.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-11T19:56:02
+# Generation date: 2026-07-01T14:24:31
 # Schema: Imaging
 #
 # id: https://w3id.org/htan/imaging

--- a/modules/Imaging/src/htan_imaging/datamodel/imaging.py
+++ b/modules/Imaging/src/htan_imaging/datamodel/imaging.py
@@ -1,5 +1,5 @@
 # Auto generated from imaging.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-07-01T14:24:31
+# Generation date: 2026-07-01T14:40:41
 # Schema: Imaging
 #
 # id: https://w3id.org/htan/imaging

--- a/modules/MassSpectrometryImaging/Makefile
+++ b/modules/MassSpectrometryImaging/Makefile
@@ -1,0 +1,37 @@
+# MassSpectrometryImaging Makefile
+
+.PHONY: all clean test gen-schema gen-synapse-schema
+
+# Environment variables
+SCHEMA_NAME = htan_massspectrometryimaging
+SOURCE_SCHEMA_PATH = domains/mass_spectrometry_imaging.yaml
+BUILD_DIR = build
+DATAMODEL_DIR = src/htan_massspectrometryimaging/datamodel
+
+all: gen-schema test
+
+# Generate Python classes and JSON schema
+gen-schema:
+	mkdir -p $(BUILD_DIR)
+	mkdir -p $(DATAMODEL_DIR)
+	poetry run gen-python $(SOURCE_SCHEMA_PATH) > $(BUILD_DIR)/mass_spectrometry_imaging.py
+	cp $(BUILD_DIR)/mass_spectrometry_imaging.py $(DATAMODEL_DIR)/
+	poetry run gen-json-schema $(SOURCE_SCHEMA_PATH) > $(BUILD_DIR)/mass_spectrometry_imaging_schema.json
+
+# Generate Synapse-compatible flat JSON schema (per level class)
+gen-synapse-schema:
+	mkdir -p $(BUILD_DIR)
+	cd ../../ && poetry run python scripts/linkml_to_flat_synapse_jsonschema.py \
+		modules/MassSpectrometryImaging/domains/level_1.yaml \
+		--class-name MassSpectrometryImagingLevel1 \
+		--output modules/MassSpectrometryImaging/$(BUILD_DIR)/mass_spectrometry_imaging_level_1.flat.schema.json
+	@echo "Synapse-compatible schema generated in $(BUILD_DIR)"
+
+# Run module-specific tests
+test:
+	cd ../../ && PYTHONPATH=. poetry run pytest modules/MassSpectrometryImaging/tests/ -v
+
+# Clean build artifacts
+clean:
+	rm -rf $(BUILD_DIR)/*
+	find . -type d -name "__pycache__" -exec rm -rf {} +

--- a/modules/MassSpectrometryImaging/README.md
+++ b/modules/MassSpectrometryImaging/README.md
@@ -52,6 +52,12 @@ cd modules/MassSpectrometryImaging
 make test
 ```
 
+The suite is schema-introspection only (via `SchemaView`): it covers class structure,
+inheritance, required/optional slots per level, enum ordering/descriptions, and the
+conditional rules. **Valid/invalid instance tests are intentionally deferred** to the
+downstream `make modules-gen` PR, because instantiating classes and exercising bad
+enum values requires the generated Python dataclasses (not produced in the schema PR).
+
 ## Schema generation
 
 Generated artifacts (Python dataclasses, JSON schemas) are produced in a separate

--- a/modules/MassSpectrometryImaging/README.md
+++ b/modules/MassSpectrometryImaging/README.md
@@ -1,0 +1,63 @@
+# HTAN Mass Spectrometry Imaging (MSI)
+
+LinkML schema for HTAN Phase 2 Mass Spectrometry Imaging, implementing the
+*HTAN Phase 2 — Mass Spectrometry Imaging (MSI)* RFC (v1.3).
+
+## Purpose
+
+MSI is a spatial molecular profiling modality that produces spatially resolved,
+label-free detection of lipids, metabolites, peptides, and proteins directly from
+tissue. Like spatial transcriptomics, MSI inherits from `CoreFileAttributes`
+(not `BaseImagingAttributes`).
+
+## Structure
+
+A 4-level hierarchy plus a per-channel RecordSet companion:
+
+| File | Class | Level |
+|---|---|---|
+| `domains/level_1.yaml` | `MassSpectrometryImagingLevel1` | Raw continuous/profile imzML acquisition annotations |
+| `domains/level_2.yaml` | `MassSpectrometryImagingLevel2` | Processed centroided imzML processing + QC annotations |
+| `domains/level_3.yaml` | `MassSpectrometryImagingLevel3` | Annotation-filtered OME-TIFF summary annotations |
+| `domains/level_4.yaml` | `MassSpectrometryImagingLevel4` | Segmentation / region quantification (optional) |
+| `domains/molecular_assignments.yaml` | `MolecularAssignment` | Molecular Assignments RecordSet (one row per OME-TIFF channel) |
+| `domains/mass_spectrometry_imaging.yaml` | `MassSpectrometryImagingData` | Container importing all of the above |
+
+Each level class is `is_a: CoreFileAttributes` (flat pattern, mirroring SpatialOmics).
+Attributes propagate downward at query time via `HTAN_PARENT_ID` — **not** via LinkML
+inheritance — so each level defines only its own new attributes. `PASSED_QC`,
+`QC_COMMENT`, `SOFTWARE_AND_VERSION`, and `PROTOCOL_LINK` are re-specified per level.
+
+The `MolecularAssignment` row class does **not** inherit `CoreFileAttributes`
+(like `ChannelMetadata` in Multiplex Microscopy); it is wired into the container
+with `multivalued: true` + `inlined_as_list: true`.
+
+## Validation highlights
+
+- `PREPARATION_MATRIX` and `MATRIX_DEPOSITION_METHOD` are conditionally required when
+  `MS_IONIZATION_TECHNIQUE` is a MALDI technique (`MALDI` / `MALDI_2`); the matrix
+  *instrument* fields are optional.
+- `ANALYTE_CLASS` is multivalued.
+- `SPECTRUM_TYPE` is fixed to `PROFILE` at Level 1.
+- The Molecular Assignments columns are gated on `CONFIDENCE_LEVEL` (1–4) via rules.
+
+Cross-row constraints (channel count = RecordSet row count; `(HTAN_DATA_FILE_ID,
+CHANNEL_INDEX)` uniqueness; imzML continuous@L1 / centroided@L2) are enforced by the
+DCC validator, not the schema.
+
+## Testing
+
+```bash
+cd modules/MassSpectrometryImaging
+make test
+```
+
+## Schema generation
+
+Generated artifacts (Python dataclasses, JSON schemas) are produced in a separate
+downstream PR:
+
+```bash
+cd modules/MassSpectrometryImaging
+make gen-schema
+```

--- a/modules/MassSpectrometryImaging/domains/level_1.yaml
+++ b/modules/MassSpectrometryImaging/domains/level_1.yaml
@@ -266,7 +266,8 @@ classes:
         range: string
         required: true
         title: "Calibrant Masses"
-        description: Comma-separated list of calibrant m/z values used.
+        description: Comma-separated list of calibrant m/z values used (e.g., "622.0290, 922.0098").
+        pattern: "^[0-9]+(\\.[0-9]+)?(, ?[0-9]+(\\.[0-9]+)?)*$"
       TIME_SINCE_ACQUISITION_INSTRUMENT_CALIBRATION_VALUE:
         range: integer
         required: true

--- a/modules/MassSpectrometryImaging/domains/level_1.yaml
+++ b/modules/MassSpectrometryImaging/domains/level_1.yaml
@@ -1,0 +1,355 @@
+name: MassSpectrometryImagingLevel1
+id: https://w3id.org/htan/mass_spectrometry_imaging/level_1
+description: HTAN Mass Spectrometry Imaging Level 1 - Raw spectral data (continuous/profile imzML) acquisition annotations
+
+imports:
+  - linkml:types
+  - linkml:extensions
+  - ../../CoreFile/domains/core
+
+prefixes:
+  htan: https://w3id.org/htan/
+  linkml: https://w3id.org/linkml/
+  schema: http://schema.org/
+
+default_prefix: htan
+
+enums:
+  MsIonizationTechniqueEnum:
+    permissible_values:
+      "DESI":
+        description: Desorption Electrospray Ionization - ambient spray ionization
+      "IR_MALDESI":
+        description: Infrared MALDESI - IR laser ablation coupled with electrospray
+      "MALDI":
+        description: Matrix-Assisted Laser Desorption/Ionization
+      "MALDI_2":
+        description: MALDI with secondary post-ionization laser for enhanced sensitivity (Bruker timsTOF Flex MALDI-2 mode)
+      "OTHER":
+        description: Ionization technique not listed; describe in PROTOCOL_LINK
+      "SIMS":
+        description: Secondary Ion Mass Spectrometry - ion beam sputtering for sub-micron resolution
+
+  MassAnalyzerTypeEnum:
+    permissible_values:
+      "FTICR":
+        description: Fourier-Transform Ion Cyclotron Resonance
+      "ION_TRAP":
+        description: Ion trap (linear or 3D)
+      "ORBITRAP":
+        description: Orbitrap electrostatic trap (Thermo)
+      "OTHER":
+        description: Analyser type not listed
+      "Q_TOF":
+        description: Quadrupole Time-of-Flight hybrid
+      "TOF":
+        description: Time-of-Flight mass analyser
+      "TRIPLE_QUADRUPOLE":
+        description: Triple-quadrupole (tandem MS)
+
+  MassAnalysisPolarityEnum:
+    permissible_values:
+      "BOTH":
+        description: Dataset contains both positive and negative mode acquisitions (HTAN extension - not present in HuBMAP)
+      "NEG":
+        description: Negative ionisation mode
+      "POS":
+        description: Positive ionisation mode
+
+  AnalyteClassEnum:
+    permissible_values:
+      "GLYCANS":
+        description: N-linked or O-linked glycans (e.g., PNGaseF-released)
+      "LIPIDS":
+        description: Lipids and fatty acids
+      "METABOLITES":
+        description: Small-molecule metabolites (non-lipid)
+      "NUCLEIC_ACIDS":
+        description: Oligonucleotides or nucleic acid species
+      "PEPTIDES":
+        description: Tryptic or enzymatically generated peptides
+      "PHARMACEUTICALS":
+        description: Drug compounds or their metabolites
+      "PROTEINS":
+        description: Intact or top-down proteins
+
+  SpectrumTypeEnum:
+    permissible_values:
+      "CENTROID":
+        description: Peak-picked spectrum; discrete m/z-intensity pairs. Required at Level 2.
+      "PROFILE":
+        description: Continuous spectrum; full peak shapes preserved. Required at Level 1.
+
+  MsScanModeEnum:
+    permissible_values:
+      "LINEAR":
+        description: Linear TOF mode; higher sensitivity for large molecules
+      "NOT_APPLICABLE":
+        description: Analyser does not use a TOF scan mode (e.g., Orbitrap, FTICR, Q-TOF hybrid)
+      "OTHER":
+        description: Scan mode not listed
+      "REFLECTRON":
+        description: Reflectron TOF mode; improved mass resolution via ion reflection
+
+  CalibrationTypeEnum:
+    permissible_values:
+      "EXTERNAL":
+        description: Calibration performed on a separate reference spot prior to acquisition
+      "INTERNAL":
+        description: Calibrant ions co-present in each spectrum during acquisition
+      "LOCK_MASS":
+        description: Real-time calibration correction using a reference ion of known m/z
+
+  TimeUnitEnum:
+    permissible_values:
+      "DAYS":
+        description: Time expressed in days
+      "HOURS":
+        description: Time expressed in hours
+
+  PreparationMatrixEnum:
+    permissible_values:
+      "9_AA":
+        description: 9-Aminoacridine; used for lipids and metabolites in negative mode
+      "CHCA":
+        description: alpha-Cyano-4-hydroxycinnamic acid; used for peptides and small proteins
+      "DAN":
+        description: 1,5-Diaminonaphthalene; used for lipids and metabolites in negative mode
+      "DHA":
+        description: 2,6-Dihydroxyacetophenone; used for oligonucleotides and acidic lipids
+      "DHB":
+        description: 2,5-Dihydroxybenzoic acid; used for lipids, oligosaccharides, and metabolites
+      "NOT_APPLICABLE":
+        description: Ionization modality does not use a matrix (DESI, SIMS, IR-MALDESI)
+      "OTHER":
+        description: Matrix compound not listed; specify in PROTOCOL_LINK
+      "SA":
+        description: Sinapinic acid; used for intact proteins >10 kDa
+
+  MatrixDepositionMethodEnum:
+    permissible_values:
+      "ELECTROSPRAY":
+        description: Electrospray-based matrix deposition
+      "NOT_APPLICABLE":
+        description: Ionization modality does not use a matrix
+      "PNEUMATIC_SPRAYER":
+        description: Automated pneumatic spray coater (e.g., HTX TM-Sprayer)
+      "ROBOTIC_SPOTTER":
+        description: Robotic micro-dispensing of discrete matrix spots
+      "SPRAY":
+        description: Pneumatic or manual aerosol spray application
+      "SUBLIMATION":
+        description: Thermal sublimation deposition for uniform crystal layer
+
+  PreAcquisitionTreatmentEnum:
+    permissible_values:
+      "NONE":
+        description: No enzymatic or chemical treatment applied before this acquisition run
+      "OTHER":
+        description: Treatment not listed; describe in PROTOCOL_LINK
+      "PNGASEF":
+        description: PNGase F enzyme applied to release N-linked glycans from glycoproteins
+      "PNGASEF_THEN_TRYPSIN":
+        description: Sequential PNGase F followed by trypsin digestion
+      "TRYPSIN":
+        description: Trypsin applied for in-tissue proteolytic digestion to generate peptides
+
+classes:
+  MassSpectrometryImagingLevel1:
+    is_a: CoreFileAttributes
+    description: Level 1 raw spectral data - continuous (profile) imzML acquisition annotations. The paired .ibd binary is an unannotated companion carrying only CoreFileAttributes.
+    attributes:
+      FILE_FORMAT:
+        range: string
+        required: true
+        title: "File Format"
+        description: Format of the file; imzML (continuous/profile) at Level 1
+        pattern: "^imzML$"
+      FILENAME:
+        range: string
+        required: true
+        title: "File Name"
+        description: Name of the file. Must end with .imzML
+        pattern: "^.+\\.imzML$"
+      MS_IONIZATION_TECHNIQUE:
+        range: MsIonizationTechniqueEnum
+        required: true
+        title: "MS Ionization Technique"
+        description: Ionization technique used. For timsTOF Flex, distinguish MALDI from MALDI_2.
+      MASS_ANALYZER_TYPE:
+        range: MassAnalyzerTypeEnum
+        required: true
+        title: "Mass Analyzer Type"
+        description: Type of mass analyzer.
+      MASS_ANALYSIS_POLARITY:
+        range: MassAnalysisPolarityEnum
+        required: true
+        title: "Mass Analysis Polarity"
+        description: Ion polarity mode for acquisition.
+      ANALYTE_CLASS:
+        range: AnalyteClassEnum
+        multivalued: true
+        required: true
+        title: "Analyte Class"
+        description: Molecular class(es) targeted by the acquisition. One or more values may be specified (e.g., a sequential metabolites/glycans/peptides workflow records each class).
+      IS_TARGETED:
+        range: boolean
+        required: true
+        title: "Is Targeted"
+        description: Whether acquisition targets a pre-specified set of molecules (true) or is untargeted (false).
+      ACQUISITION_INSTRUMENT_VENDOR:
+        range: string
+        required: true
+        title: "Acquisition Instrument Vendor"
+        description: Manufacturer of the mass spectrometer (e.g., Bruker, Waters, Thermo).
+      ACQUISITION_INSTRUMENT_MODEL:
+        range: string
+        required: true
+        title: "Acquisition Instrument Model"
+        description: Specific instrument model (e.g., timsTOF Flex, Q Exactive).
+      PIXEL_SIZE_X_UM:
+        range: float
+        required: true
+        title: "Pixel Size X (um)"
+        description: Pixel pitch in the X dimension (micrometers); corresponds to PSI-MS CV MS:1000042.
+        minimum_value: 0.0
+      PIXEL_SIZE_Y_UM:
+        range: float
+        required: true
+        title: "Pixel Size Y (um)"
+        description: Pixel pitch in the Y dimension (micrometers); corresponds to PSI-MS CV MS:1000043.
+        minimum_value: 0.0
+      MASS_TO_CHARGE_RANGE_LOW_VALUE:
+        range: float
+        required: true
+        title: "Mass-to-Charge Range Low Value"
+        description: Lower m/z boundary of the acquisition range.
+        minimum_value: 0.0
+      MASS_TO_CHARGE_RANGE_HIGH_VALUE:
+        range: float
+        required: true
+        title: "Mass-to-Charge Range High Value"
+        description: Upper m/z boundary of the acquisition range.
+        minimum_value: 0.0
+      ION_MOBILITY:
+        range: boolean
+        required: true
+        title: "Ion Mobility"
+        description: Whether ion mobility separation was applied during acquisition.
+      SPECTRUM_TYPE:
+        range: SpectrumTypeEnum
+        required: true
+        title: "Spectrum Type"
+        description: Spectral representation type. Must be PROFILE at Level 1.
+      MASS_RESOLVING_POWER:
+        range: integer
+        required: true
+        title: "Mass Resolving Power"
+        description: Mass resolving power (m/delta-m) of the instrument.
+        minimum_value: 0
+      MASS_TO_CHARGE_RESOLVING_POWER:
+        range: float
+        required: false
+        title: "Mass-to-Charge Resolving Power"
+        description: m/z value at which MASS_RESOLVING_POWER is specified. Recommended.
+      MS_SCAN_MODE:
+        range: MsScanModeEnum
+        required: true
+        title: "MS Scan Mode"
+        description: Scan mode of the mass analyser (TOF-specific; NOT_APPLICABLE for non-TOF analysers).
+      CALIBRATION_TYPE:
+        range: CalibrationTypeEnum
+        required: true
+        title: "Calibration Type"
+        description: Type of mass calibration applied.
+      CALIBRANT_MASSES:
+        range: string
+        required: true
+        title: "Calibrant Masses"
+        description: Comma-separated list of calibrant m/z values used.
+      TIME_SINCE_ACQUISITION_INSTRUMENT_CALIBRATION_VALUE:
+        range: integer
+        required: true
+        title: "Time Since Acquisition Instrument Calibration Value"
+        description: Elapsed time since the last instrument mass calibration.
+        minimum_value: 0
+      TIME_SINCE_ACQUISITION_INSTRUMENT_CALIBRATION_UNIT:
+        range: TimeUnitEnum
+        required: true
+        title: "Time Since Acquisition Instrument Calibration Unit"
+        description: Unit for TIME_SINCE_ACQUISITION_INSTRUMENT_CALIBRATION_VALUE.
+      SOFTWARE_AND_VERSION:
+        range: string
+        required: true
+        title: "Software and Version"
+        description: Name and version of the acquisition software used to collect data (e.g., flexImaging 7.0, timsControl 5.1). Re-specified at each level.
+      PROTOCOL_LINK:
+        range: string
+        required: false
+        title: "Protocol Link"
+        description: URL or DOI of the tissue preparation and matrix deposition protocol (e.g., protocols.io link). Recommended. Re-specified at each level.
+      IBD_FILE_UUID:
+        range: string
+        required: true
+        title: "IBD File UUID"
+        description: UUID embedded in the .imzML XML linking to the paired .ibd binary file.
+      PREPARATION_MATRIX:
+        range: PreparationMatrixEnum
+        required: false
+        title: "Preparation Matrix"
+        description: MALDI matrix compound applied to the tissue section. Conditionally required when MS_IONIZATION_TECHNIQUE is MALDI or MALDI_2; set NOT_APPLICABLE for non-MALDI modalities.
+      MATRIX_DEPOSITION_METHOD:
+        range: MatrixDepositionMethodEnum
+        required: false
+        title: "Matrix Deposition Method"
+        description: Method used to apply the MALDI matrix to tissue. Conditionally required when MS_IONIZATION_TECHNIQUE is MALDI or MALDI_2.
+      PREPARATION_INSTRUMENT_VENDOR:
+        range: string
+        required: false
+        title: "Preparation Instrument Vendor"
+        description: Manufacturer of the matrix deposition instrument. Optional.
+      PREPARATION_INSTRUMENT_MODEL:
+        range: string
+        required: false
+        title: "Preparation Instrument Model"
+        description: Model of the matrix deposition instrument. Optional.
+      ANALYTE_ACQUISITION_ORDER:
+        range: integer
+        required: false
+        title: "Analyte Acquisition Order"
+        description: 1-based order of this run within a sequential multi-analyte session on the same tissue section. Recommended; required when multiple analyte classes are acquired from one section.
+        minimum_value: 1
+      PRE_ACQUISITION_TREATMENT:
+        range: PreAcquisitionTreatmentEnum
+        required: false
+        title: "Pre-Acquisition Treatment"
+        description: Enzymatic or chemical treatment applied to the section prior to this acquisition run. Recommended.
+      PASSED_QC:
+        range: boolean
+        required: true
+        title: "Passed QC"
+        description: Whether the file passed post-acquisition quality control at Level 1.
+      QC_COMMENT:
+        range: string
+        required: false
+        title: "QC Comment"
+        description: Free-text quality-control comment for Level 1.
+    rules:
+      - description: "SPECTRUM_TYPE must be PROFILE at Level 1 (continuous/profile imzML)"
+        postconditions:
+          slot_conditions:
+            SPECTRUM_TYPE:
+              equals_string: "PROFILE"
+      - description: "PREPARATION_MATRIX and MATRIX_DEPOSITION_METHOD are required when MS_IONIZATION_TECHNIQUE is a MALDI technique (MALDI or MALDI_2)"
+        preconditions:
+          slot_conditions:
+            MS_IONIZATION_TECHNIQUE:
+              any_of:
+                - equals_string: "MALDI"
+                - equals_string: "MALDI_2"
+        postconditions:
+          slot_conditions:
+            PREPARATION_MATRIX:
+              required: true
+            MATRIX_DEPOSITION_METHOD:
+              required: true

--- a/modules/MassSpectrometryImaging/domains/level_2.yaml
+++ b/modules/MassSpectrometryImaging/domains/level_2.yaml
@@ -1,0 +1,156 @@
+name: MassSpectrometryImagingLevel2
+id: https://w3id.org/htan/mass_spectrometry_imaging/level_2
+description: HTAN Mass Spectrometry Imaging Level 2 - Processed spectral data (centroided imzML) processing and QC annotations
+
+imports:
+  - linkml:types
+  - linkml:extensions
+  - ../../CoreFile/domains/core
+
+prefixes:
+  htan: https://w3id.org/htan/
+  linkml: https://w3id.org/linkml/
+  schema: http://schema.org/
+
+default_prefix: htan
+
+enums:
+  BaselineCorrectionMethodEnum:
+    permissible_values:
+      "NONE":
+        description: No baseline correction applied
+      "OTHER":
+        description: Algorithm not listed; specify in SOFTWARE_AND_VERSION or PROTOCOL_LINK
+      "SNIP":
+        description: Statistics-sensitive Non-linear Iterative Peak-clipping algorithm
+      "TOP_HAT":
+        description: Top-hat morphological filter for baseline estimation
+
+  NormalizationMethodEnum:
+    permissible_values:
+      "MEDIAN":
+        description: Median spectrum intensity normalization
+      "NONE":
+        description: No normalization applied
+      "OTHER":
+        description: Method not listed; specify in PROTOCOL_LINK
+      "REFERENCE_PEAK":
+        description: Normalization to a single reference m/z peak of known abundance
+      "RMS":
+        description: Root Mean Square normalization
+      "TIC":
+        description: Total Ion Current normalization - divide each spectrum by its TIC
+
+  SmoothingMethodEnum:
+    permissible_values:
+      "GAUSSIAN":
+        description: Gaussian kernel smoothing
+      "NONE":
+        description: No spectral smoothing applied
+      "OTHER":
+        description: Method not listed; specify in PROTOCOL_LINK
+      "SAVITZKY_GOLAY":
+        description: Savitzky-Golay polynomial smoothing filter
+
+classes:
+  MassSpectrometryImagingLevel2:
+    is_a: CoreFileAttributes
+    description: Level 2 processed spectral data - centroided imzML after baseline correction, peak picking, mass alignment, and normalization. The paired .ibd binary is an unannotated companion.
+    attributes:
+      FILE_FORMAT:
+        range: string
+        required: true
+        title: "File Format"
+        description: Format of the file; processed (centroided) imzML at Level 2
+        pattern: "^imzML$"
+      FILENAME:
+        range: string
+        required: true
+        title: "File Name"
+        description: Name of the file. Must end with .imzML
+        pattern: "^.+\\.imzML$"
+      SOFTWARE_AND_VERSION:
+        range: string
+        required: true
+        title: "Software and Version"
+        description: Name and version of the spectral processing software used at this level (e.g., SCiLS Lab 2024, Cardinal 3.4). Re-specified at each level; not propagated from L1.
+      BASELINE_CORRECTION_METHOD:
+        range: BaselineCorrectionMethodEnum
+        required: true
+        title: "Baseline Correction Method"
+        description: Baseline correction algorithm applied prior to peak picking.
+      PEAK_PICKING_METHOD:
+        range: string
+        required: true
+        title: "Peak Picking Method"
+        description: Peak detection algorithm used (e.g., centroid, continuous wavelet transform).
+      PEAK_PICKING_SNR_THRESHOLD:
+        range: float
+        required: true
+        title: "Peak Picking SNR Threshold"
+        description: Signal-to-noise ratio threshold applied during peak picking.
+        minimum_value: 0.0
+      NORMALIZATION_METHOD:
+        range: NormalizationMethodEnum
+        required: true
+        title: "Normalization Method"
+        description: Spectral intensity normalization method applied.
+      MASS_ALIGNMENT_METHOD:
+        range: string
+        required: true
+        title: "Mass Alignment Method"
+        description: Algorithm used to align m/z peaks across all pixels (e.g., lock-mass, landmark-based).
+      MASS_TOLERANCE_PPM:
+        range: float
+        required: true
+        title: "Mass Tolerance (ppm)"
+        description: Mass tolerance (ppm) applied during peak binning and alignment.
+      SMOOTHING_METHOD:
+        range: SmoothingMethodEnum
+        required: false
+        title: "Smoothing Method"
+        description: Spectral smoothing algorithm applied; NONE if no smoothing.
+      PROTOCOL_LINK:
+        range: string
+        required: false
+        title: "Protocol Link"
+        description: URL or DOI of the data processing and analysis protocol for this level. Recommended. Re-specified at each level; not propagated from L1.
+      MEDIAN_TIC:
+        range: float
+        required: true
+        title: "Median TIC"
+        description: Median total ion current across all pixels after normalization.
+      TIC_CV:
+        range: float
+        required: true
+        title: "TIC CV"
+        description: Coefficient of variation (%) of the total ion current across pixels; acceptance threshold <30%.
+        minimum_value: 0.0
+      MASS_ACCURACY_PPM:
+        range: float
+        required: true
+        title: "Mass Accuracy (ppm)"
+        description: Mean absolute mass error (ppm) measured against calibrant peaks.
+      PIXEL_COMPLETION_RATE:
+        range: float
+        required: true
+        title: "Pixel Completion Rate"
+        description: Fraction (0-100%) of expected raster pixels successfully acquired.
+        minimum_value: 0.0
+        maximum_value: 100.0
+      NUM_DETECTED_PEAKS:
+        range: integer
+        required: true
+        title: "Number of Detected Peaks"
+        description: Total number of unique m/z features detected after peak picking across the dataset.
+        minimum_value: 0
+      PASSED_QC:
+        range: boolean
+        required: true
+        title: "Passed QC"
+        description: Whether the file passed processing-stage quality control at Level 2.
+      QC_COMMENT:
+        range: string
+        required: false
+        title: "QC Comment"
+        description: Free-text quality-control comment for Level 2.

--- a/modules/MassSpectrometryImaging/domains/level_3.yaml
+++ b/modules/MassSpectrometryImaging/domains/level_3.yaml
@@ -1,0 +1,65 @@
+name: MassSpectrometryImagingLevel3
+id: https://w3id.org/htan/mass_spectrometry_imaging/level_3
+description: HTAN Mass Spectrometry Imaging Level 3 - Annotation-filtered OME-TIFF summary annotations (per-channel detail lives in the Molecular Assignments RecordSet)
+
+imports:
+  - linkml:types
+  - linkml:extensions
+  - ../../CoreFile/domains/core
+
+prefixes:
+  htan: https://w3id.org/htan/
+  linkml: https://w3id.org/linkml/
+  schema: http://schema.org/
+
+default_prefix: htan
+
+classes:
+  MassSpectrometryImagingLevel3:
+    is_a: CoreFileAttributes
+    description: Level 3 annotation-filtered OME-TIFF. Channels include only annotated m/z values plus biologically relevant unknowns. Per-channel molecular detail is carried by the companion Molecular Assignments RecordSet.
+    attributes:
+      FILE_FORMAT:
+        range: string
+        required: true
+        title: "File Format"
+        description: Format of the file; OME-TIFF at Level 3
+        pattern: "^ome\\.tiff?$"
+      FILENAME:
+        range: string
+        required: true
+        title: "File Name"
+        description: Name of the file. Must end with .ome.tif or .ome.tiff
+        pattern: "^.+\\.ome\\.tiff?$"
+      NUM_ANNOTATED_CHANNELS:
+        range: integer
+        required: true
+        title: "Number of Annotated Channels"
+        description: Number of OME-TIFF channels with a confirmed molecular assignment (confidence levels 1-3).
+        minimum_value: 0
+      NUM_UNKNOWN_CHANNELS:
+        range: integer
+        required: true
+        title: "Number of Unknown Channels"
+        description: Number of OME-TIFF channels retained as biologically relevant unknowns (confidence level 4).
+        minimum_value: 0
+      SOFTWARE_AND_VERSION:
+        range: string
+        required: true
+        title: "Software and Version"
+        description: Name and version of the annotation software used at this level. Re-specified at each level; not propagated.
+      PROTOCOL_LINK:
+        range: string
+        required: false
+        title: "Protocol Link"
+        description: URL or DOI of the molecular annotation protocol for this level. Recommended; documents the annotation method per RFC section 4.3.
+      PASSED_QC:
+        range: boolean
+        required: true
+        title: "Passed QC"
+        description: Whether the file passed quality control at Level 3.
+      QC_COMMENT:
+        range: string
+        required: false
+        title: "QC Comment"
+        description: Free-text quality-control comment for Level 3.

--- a/modules/MassSpectrometryImaging/domains/level_4.yaml
+++ b/modules/MassSpectrometryImaging/domains/level_4.yaml
@@ -1,0 +1,71 @@
+name: MassSpectrometryImagingLevel4
+id: https://w3id.org/htan/mass_spectrometry_imaging/level_4
+description: HTAN Mass Spectrometry Imaging Level 4 - Segmented and region/cell-type quantified output (optional level)
+
+imports:
+  - linkml:types
+  - linkml:extensions
+  - ../../CoreFile/domains/core
+
+prefixes:
+  htan: https://w3id.org/htan/
+  linkml: https://w3id.org/linkml/
+  schema: http://schema.org/
+
+default_prefix: htan
+
+enums:
+  SegmentationReferenceModalityEnum:
+    permissible_values:
+      "H_AND_E":
+        description: Segmentation derived from H&E staining and projected onto MSI pixels
+      "IF":
+        description: Segmentation derived from immunofluorescence
+      "MSI_NATIVE":
+        description: Segmentation derived directly from MSI spectral clustering (no external reference)
+      "OTHER":
+        description: Reference modality not listed
+
+classes:
+  MassSpectrometryImagingLevel4:
+    is_a: CoreFileAttributes
+    description: Level 4 segmented and region/cell-type quantified output (optional). Includes a segmentation mask OME-TIFF and/or a region quantification table.
+    attributes:
+      FILE_FORMAT:
+        range: string
+        required: true
+        title: "File Format"
+        description: Format of the file; OME-TIFF segmentation mask or CSV quantification table
+        pattern: "^(ome\\.tiff?|csv)$"
+      FILENAME:
+        range: string
+        required: true
+        title: "File Name"
+        description: Name of the file. Must end with .ome.tif, .ome.tiff, or .csv
+        pattern: "^.+\\.(ome\\.tiff?|csv)$"
+      SEGMENTATION_METHOD:
+        range: string
+        required: true
+        title: "Segmentation Method"
+        description: Algorithm or tool used for tissue or cell-type segmentation (e.g., K-means on TIC image, H&E-guided).
+      SEGMENTATION_CLASS_COUNT:
+        range: integer
+        required: true
+        title: "Segmentation Class Count"
+        description: Number of distinct tissue regions or cell types identified by the segmentation.
+        minimum_value: 1
+      SEGMENTATION_REFERENCE_MODALITY:
+        range: SegmentationReferenceModalityEnum
+        required: true
+        title: "Segmentation Reference Modality"
+        description: Modality whose segmentation output was projected onto the MSI image.
+      PASSED_QC:
+        range: boolean
+        required: true
+        title: "Passed QC"
+        description: Whether the file passed quality control at Level 4.
+      QC_COMMENT:
+        range: string
+        required: false
+        title: "QC Comment"
+        description: Free-text quality-control comment for Level 4.

--- a/modules/MassSpectrometryImaging/domains/mass_spectrometry_imaging.yaml
+++ b/modules/MassSpectrometryImaging/domains/mass_spectrometry_imaging.yaml
@@ -19,32 +19,33 @@ prefixes:
 
 default_prefix: htan
 
-slots:
-  caDSR_id:
-    description: The caDSR identifier for this element
-    range: string
-    multivalued: false
-    required: false
-
 classes:
   MassSpectrometryImagingData:
     description: Container for all Mass Spectrometry Imaging data levels and the Molecular Assignments RecordSet
     attributes:
       LEVEL_1_DATA:
         range: MassSpectrometryImagingLevel1
+        inlined: true
         required: false
+        title: "Level 1 Data"
         description: Level 1 MSI data (raw continuous/profile imzML), required for MSI submissions
       LEVEL_2_DATA:
         range: MassSpectrometryImagingLevel2
+        inlined: true
         required: false
+        title: "Level 2 Data"
         description: Level 2 MSI data (processed centroided imzML), required for MSI submissions
       LEVEL_3_DATA:
         range: MassSpectrometryImagingLevel3
+        inlined: true
         required: false
+        title: "Level 3 Data"
         description: Level 3 MSI data (annotation-filtered OME-TIFF), required for MSI submissions
       LEVEL_4_DATA:
         range: MassSpectrometryImagingLevel4
+        inlined: true
         required: false
+        title: "Level 4 Data"
         description: Level 4 MSI data (segmentation mask / region quantification), optional
       MOLECULAR_ASSIGNMENTS:
         range: MolecularAssignment

--- a/modules/MassSpectrometryImaging/domains/mass_spectrometry_imaging.yaml
+++ b/modules/MassSpectrometryImaging/domains/mass_spectrometry_imaging.yaml
@@ -1,0 +1,55 @@
+name: MassSpectrometryImaging
+id: https://w3id.org/htan/mass_spectrometry_imaging
+description: HTAN Mass Spectrometry Imaging (MSI) Data Model Schema for Phase 2 - All Levels
+
+imports:
+  - linkml:types
+  - linkml:extensions
+  - ../../CoreFile/domains/core
+  - level_1
+  - level_2
+  - level_3
+  - level_4
+  - molecular_assignments
+
+prefixes:
+  htan: https://w3id.org/htan/
+  linkml: https://w3id.org/linkml/
+  schema: http://schema.org/
+
+default_prefix: htan
+
+slots:
+  caDSR_id:
+    description: The caDSR identifier for this element
+    range: string
+    multivalued: false
+    required: false
+
+classes:
+  MassSpectrometryImagingData:
+    description: Container for all Mass Spectrometry Imaging data levels and the Molecular Assignments RecordSet
+    attributes:
+      LEVEL_1_DATA:
+        range: MassSpectrometryImagingLevel1
+        required: false
+        description: Level 1 MSI data (raw continuous/profile imzML), required for MSI submissions
+      LEVEL_2_DATA:
+        range: MassSpectrometryImagingLevel2
+        required: false
+        description: Level 2 MSI data (processed centroided imzML), required for MSI submissions
+      LEVEL_3_DATA:
+        range: MassSpectrometryImagingLevel3
+        required: false
+        description: Level 3 MSI data (annotation-filtered OME-TIFF), required for MSI submissions
+      LEVEL_4_DATA:
+        range: MassSpectrometryImagingLevel4
+        required: false
+        description: Level 4 MSI data (segmentation mask / region quantification), optional
+      MOLECULAR_ASSIGNMENTS:
+        range: MolecularAssignment
+        multivalued: true
+        inlined_as_list: true
+        required: false
+        title: "Molecular Assignments"
+        description: Molecular Assignments RecordSet - one row per Level 3 OME-TIFF channel

--- a/modules/MassSpectrometryImaging/domains/molecular_assignments.yaml
+++ b/modules/MassSpectrometryImaging/domains/molecular_assignments.yaml
@@ -162,6 +162,7 @@ classes:
         preconditions:
           slot_conditions:
             CONFIDENCE_LEVEL:
+              minimum_value: 1
               maximum_value: 3
         postconditions:
           slot_conditions:
@@ -175,6 +176,7 @@ classes:
         preconditions:
           slot_conditions:
             CONFIDENCE_LEVEL:
+              minimum_value: 1
               maximum_value: 2
         postconditions:
           slot_conditions:

--- a/modules/MassSpectrometryImaging/domains/molecular_assignments.yaml
+++ b/modules/MassSpectrometryImaging/domains/molecular_assignments.yaml
@@ -1,0 +1,213 @@
+name: MassSpectrometryImagingMolecularAssignments
+id: https://w3id.org/htan/mass_spectrometry_imaging/molecular_assignments
+description: HTAN Mass Spectrometry Imaging Molecular Assignments RecordSet - per-channel molecular detail companion to the Level 3 OME-TIFF (one row per OME-TIFF channel)
+
+imports:
+  - linkml:types
+  - linkml:extensions
+
+prefixes:
+  htan: https://w3id.org/htan/
+  linkml: https://w3id.org/linkml/
+  schema: http://schema.org/
+
+default_prefix: htan
+
+enums:
+  AdductEnum:
+    permissible_values:
+      "M_MINUS_H":
+        description: "[M-H]- deprotonated molecule, most common negative mode adduct"
+      "M_PLUS_CL":
+        description: "[M+Cl]- chloride adduct"
+      "M_PLUS_H":
+        description: "[M+H]+ protonated molecule, most common positive mode adduct"
+      "M_PLUS_K":
+        description: "[M+K]+ potassium adduct"
+      "M_PLUS_NA":
+        description: "[M+Na]+ sodium adduct, common for lipids and carbohydrates"
+      "M_PLUS_NH4":
+        description: "[M+NH4]+ ammonium adduct"
+      "M_RADICAL_MINUS":
+        description: "[M]- radical anion"
+      "M_RADICAL_PLUS":
+        description: "[M]+ radical cation (SIMS, some MALDI applications)"
+      "NOT_APPLICABLE":
+        description: No adduct applicable (confidence level 4 unknowns)
+      "OTHER":
+        description: Adduct not listed; specify in MOLECULAR_NAME or annotation protocol
+
+  DatabaseSourceEnum:
+    permissible_values:
+      "CHEBI":
+        description: Chemical Entities of Biological Interest (https://ebi.ac.uk/chebi)
+      "CUSTOM":
+        description: In-house or custom reference database; describe in PROTOCOL_LINK
+      "GLYCONNECT":
+        description: GlyConnect glycan database (https://glyconnect.expasy.org)
+      "GLYTOUCAN":
+        description: GlyTouCan glycan repository (https://glytoucan.org)
+      "HMDB":
+        description: Human Metabolome Database (https://hmdb.ca)
+      "LIPID_MAPS":
+        description: LIPID MAPS Structure Database (https://lipidmaps.org)
+      "MASSBANK":
+        description: MassBank spectral database (https://massbank.eu)
+      "METLIN":
+        description: METLIN metabolite and chemical database (https://metlin.scripps.edu)
+      "NOT_APPLICABLE":
+        description: No database assignment applicable (confidence level 4 unknowns)
+      "PUBCHEM":
+        description: PubChem compound database (https://pubchem.ncbi.nlm.nih.gov)
+      "UNIPROT":
+        description: Universal Protein Resource for protein identifications (https://uniprot.org)
+
+  EvidenceTypeEnum:
+    permissible_values:
+      "ACCURATE_MASS":
+        description: Annotation supported by accurate mass match within tolerance
+      "DATABASE_SPECTRAL_MATCH":
+        description: Matched to a spectral library entry in a public database
+      "ISOTOPE_PATTERN":
+        description: Annotation supported by isotope pattern matching
+      "MSMS_MATCH":
+        description: Annotation supported by MS/MS fragmentation spectrum match
+      "REFERENCE_STANDARD":
+        description: Confirmed by comparison to an authenticated in-house reference standard
+      "SPATIAL_PATTERN_ONLY":
+        description: Retained for biological relevance based on spatial distribution; no structural assignment
+
+classes:
+  MolecularAssignment:
+    description: A single molecular assignment row corresponding to one OME-TIFF channel in a Level 3 file. The unique row key is (HTAN_DATA_FILE_ID, CHANNEL_INDEX). Channel count must equal RecordSet row count (enforced by the DCC validator).
+    attributes:
+      HTAN_DATA_FILE_ID:
+        range: string
+        required: true
+        title: "HTAN Data File ID"
+        description: Foreign key to the parent Level 3 OME-TIFF file ID (same value for all rows in a RecordSet). Follows the HTAN data file ID pattern (D-suffix).
+        pattern: "^(?=.{1,50}$)(HTA2[0-2][0-9])_(0000|EXT[0-9]{1,18}|[0-9]{1,21})_(D[0-9]{1,20})$"
+      CHANNEL_INDEX:
+        range: integer
+        required: true
+        title: "Channel Index"
+        description: 1-based channel number matching OME-TIFF channel order; must be unique per file.
+        minimum_value: 1
+      MZ_OBSERVED:
+        range: float
+        required: true
+        title: "m/z Observed"
+        description: Observed mass-to-charge ratio (greater than 0; 4 decimal places minimum).
+        minimum_value: 0.0
+      MZ_THEORETICAL:
+        range: float
+        required: false
+        title: "m/z Theoretical"
+        description: Theoretical mass-to-charge ratio of the assigned molecule. Required if CONFIDENCE_LEVEL is 1, 2, or 3; absent if CONFIDENCE_LEVEL is 4.
+      MASS_ERROR_PPM:
+        range: float
+        required: false
+        title: "Mass Error (ppm)"
+        description: Mass error in ppm between observed and theoretical m/z. Required if MZ_THEORETICAL is present (typical range -50 to +50).
+      MOLECULAR_FORMULA:
+        range: string
+        required: false
+        title: "Molecular Formula"
+        description: Molecular formula in Hill notation (e.g., C47H81O13P). Required if CONFIDENCE_LEVEL is 1 or 2.
+      MOLECULAR_NAME:
+        range: string
+        required: true
+        title: "Molecular Name"
+        description: Free-text molecular name or "unknown"; must match the channel name in the OME-TIFF.
+      ADDUCT:
+        range: AdductEnum
+        required: false
+        title: "Adduct"
+        description: Ion adduct form for this assignment. Required if CONFIDENCE_LEVEL is 1, 2, or 3.
+      DATABASE_SOURCE:
+        range: DatabaseSourceEnum
+        required: false
+        title: "Database Source"
+        description: Reference database used for the molecular assignment. Required if CONFIDENCE_LEVEL is 1, 2, or 3.
+      DATABASE_ID:
+        range: string
+        required: false
+        title: "Database ID"
+        description: Identifier of the assigned molecule in the named database. Required if DATABASE_SOURCE is not NOT_APPLICABLE.
+      DATABASE_VERSION:
+        range: string
+        required: false
+        title: "Database Version"
+        description: Version/release of the named database (YYYY-MM preferred). Required if DATABASE_SOURCE is not NOT_APPLICABLE.
+      SOFTWARE_AND_VERSION:
+        range: string
+        required: true
+        title: "Software and Version"
+        description: Name and version of the annotation software (e.g., Metabascape 5.0, Metaspace 2024, Cardinal 3.4).
+      CONFIDENCE_LEVEL:
+        range: integer
+        required: true
+        title: "Confidence Level"
+        description: MSI molecular-identification confidence tier. 1 = identified; 2 = putatively annotated; 3 = compound class; 4 = unknown.
+        minimum_value: 1
+        maximum_value: 4
+      EVIDENCE_TYPE:
+        range: EvidenceTypeEnum
+        multivalued: true
+        required: true
+        title: "Evidence Type"
+        description: One or more evidence types supporting the annotation (pipe-separated in the TSV). At least one value required.
+    rules:
+      - description: "MZ_THEORETICAL, ADDUCT, and DATABASE_SOURCE are required when CONFIDENCE_LEVEL is 1, 2, or 3"
+        preconditions:
+          slot_conditions:
+            CONFIDENCE_LEVEL:
+              maximum_value: 3
+        postconditions:
+          slot_conditions:
+            MZ_THEORETICAL:
+              required: true
+            ADDUCT:
+              required: true
+            DATABASE_SOURCE:
+              required: true
+      - description: "MOLECULAR_FORMULA is required when CONFIDENCE_LEVEL is 1 or 2"
+        preconditions:
+          slot_conditions:
+            CONFIDENCE_LEVEL:
+              maximum_value: 2
+        postconditions:
+          slot_conditions:
+            MOLECULAR_FORMULA:
+              required: true
+      - description: "MZ_THEORETICAL must be absent when CONFIDENCE_LEVEL is 4 (unknown)"
+        preconditions:
+          slot_conditions:
+            CONFIDENCE_LEVEL:
+              minimum_value: 4
+        postconditions:
+          slot_conditions:
+            MZ_THEORETICAL:
+              value_presence: ABSENT
+      - description: "MASS_ERROR_PPM is required when MZ_THEORETICAL is present"
+        preconditions:
+          slot_conditions:
+            MZ_THEORETICAL:
+              value_presence: PRESENT
+        postconditions:
+          slot_conditions:
+            MASS_ERROR_PPM:
+              required: true
+      - description: "DATABASE_ID and DATABASE_VERSION are required when DATABASE_SOURCE is a real database (not NOT_APPLICABLE)"
+        preconditions:
+          slot_conditions:
+            DATABASE_SOURCE:
+              value_presence: PRESENT
+              none_of:
+                - equals_string: "NOT_APPLICABLE"
+        postconditions:
+          slot_conditions:
+            DATABASE_ID:
+              required: true
+            DATABASE_VERSION:
+              required: true

--- a/modules/MassSpectrometryImaging/src/htan_massspectrometryimaging/__init__.py
+++ b/modules/MassSpectrometryImaging/src/htan_massspectrometryimaging/__init__.py
@@ -1,0 +1,1 @@
+"""HTAN MassSpectrometryImaging package."""

--- a/modules/MassSpectrometryImaging/src/htan_massspectrometryimaging/datamodel/__init__.py
+++ b/modules/MassSpectrometryImaging/src/htan_massspectrometryimaging/datamodel/__init__.py
@@ -1,0 +1,1 @@
+"""HTAN MassSpectrometryImaging data model."""

--- a/modules/MassSpectrometryImaging/src/htan_massspectrometryimaging/datamodel/mass_spectrometry_imaging.py
+++ b/modules/MassSpectrometryImaging/src/htan_massspectrometryimaging/datamodel/mass_spectrometry_imaging.py
@@ -1,0 +1,1443 @@
+# Auto generated from mass_spectrometry_imaging.yaml by pythongen.py version: 0.0.1
+# Generation date: 2026-07-01T14:24:40
+# Schema: MassSpectrometryImaging
+#
+# id: https://w3id.org/htan/mass_spectrometry_imaging
+# description: HTAN Mass Spectrometry Imaging (MSI) Data Model Schema for Phase 2 - All Levels
+# license: https://creativecommons.org/publicdomain/zero/1.0/
+
+import dataclasses
+import re
+from dataclasses import dataclass
+from datetime import (
+    date,
+    datetime,
+    time
+)
+from typing import (
+    Any,
+    ClassVar,
+    Dict,
+    List,
+    Optional,
+    Union
+)
+
+from jsonasobj2 import (
+    JsonObj,
+    as_dict
+)
+from linkml_runtime.linkml_model.meta import (
+    EnumDefinition,
+    PermissibleValue,
+    PvFormulaOptions
+)
+from linkml_runtime.utils.curienamespace import CurieNamespace
+from linkml_runtime.utils.dataclass_extensions_376 import dataclasses_init_fn_with_kwargs
+from linkml_runtime.utils.enumerations import EnumDefinitionImpl
+from linkml_runtime.utils.formatutils import (
+    camelcase,
+    sfx,
+    underscore
+)
+from linkml_runtime.utils.metamodelcore import (
+    bnode,
+    empty_dict,
+    empty_list
+)
+from linkml_runtime.utils.slot import Slot
+from linkml_runtime.utils.yamlutils import (
+    YAMLRoot,
+    extended_float,
+    extended_int,
+    extended_str
+)
+from rdflib import (
+    Namespace,
+    URIRef
+)
+
+from linkml_runtime.linkml_model.types import Boolean, Float, Integer, String
+from linkml_runtime.utils.metamodelcore import Bool
+
+metamodel_version = "1.7.0"
+version = None
+
+# Overwrite dataclasses _init_fn to add **kwargs in __init__
+dataclasses._init_fn = dataclasses_init_fn_with_kwargs
+
+# Namespaces
+HTAN = CurieNamespace('htan', 'https://w3id.org/htan/')
+LINKML = CurieNamespace('linkml', 'https://w3id.org/linkml/')
+SCHEMA = CurieNamespace('schema', 'http://schema.org/')
+DEFAULT_ = HTAN
+
+
+# Types
+
+# Class references
+class CoreFileAttributesHTANDATAFILEID(extended_str):
+    pass
+
+
+class MassSpectrometryImagingLevel1HTANDATAFILEID(CoreFileAttributesHTANDATAFILEID):
+    pass
+
+
+class MassSpectrometryImagingLevel2HTANDATAFILEID(CoreFileAttributesHTANDATAFILEID):
+    pass
+
+
+class MassSpectrometryImagingLevel3HTANDATAFILEID(CoreFileAttributesHTANDATAFILEID):
+    pass
+
+
+class MassSpectrometryImagingLevel4HTANDATAFILEID(CoreFileAttributesHTANDATAFILEID):
+    pass
+
+
+@dataclass(repr=False)
+class MassSpectrometryImagingData(YAMLRoot):
+    """
+    Container for all Mass Spectrometry Imaging data levels and the Molecular Assignments RecordSet
+    """
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = HTAN["MassSpectrometryImagingData"]
+    class_class_curie: ClassVar[str] = "htan:MassSpectrometryImagingData"
+    class_name: ClassVar[str] = "MassSpectrometryImagingData"
+    class_model_uri: ClassVar[URIRef] = HTAN.MassSpectrometryImagingData
+
+    LEVEL_1_DATA: Optional[Union[str, MassSpectrometryImagingLevel1HTANDATAFILEID]] = None
+    LEVEL_2_DATA: Optional[Union[str, MassSpectrometryImagingLevel2HTANDATAFILEID]] = None
+    LEVEL_3_DATA: Optional[Union[str, MassSpectrometryImagingLevel3HTANDATAFILEID]] = None
+    LEVEL_4_DATA: Optional[Union[str, MassSpectrometryImagingLevel4HTANDATAFILEID]] = None
+    MOLECULAR_ASSIGNMENTS: Optional[Union[Union[dict, "MolecularAssignment"], List[Union[dict, "MolecularAssignment"]]]] = empty_list()
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self.LEVEL_1_DATA is not None and not isinstance(self.LEVEL_1_DATA, MassSpectrometryImagingLevel1HTANDATAFILEID):
+            self.LEVEL_1_DATA = MassSpectrometryImagingLevel1HTANDATAFILEID(self.LEVEL_1_DATA)
+
+        if self.LEVEL_2_DATA is not None and not isinstance(self.LEVEL_2_DATA, MassSpectrometryImagingLevel2HTANDATAFILEID):
+            self.LEVEL_2_DATA = MassSpectrometryImagingLevel2HTANDATAFILEID(self.LEVEL_2_DATA)
+
+        if self.LEVEL_3_DATA is not None and not isinstance(self.LEVEL_3_DATA, MassSpectrometryImagingLevel3HTANDATAFILEID):
+            self.LEVEL_3_DATA = MassSpectrometryImagingLevel3HTANDATAFILEID(self.LEVEL_3_DATA)
+
+        if self.LEVEL_4_DATA is not None and not isinstance(self.LEVEL_4_DATA, MassSpectrometryImagingLevel4HTANDATAFILEID):
+            self.LEVEL_4_DATA = MassSpectrometryImagingLevel4HTANDATAFILEID(self.LEVEL_4_DATA)
+
+        if not isinstance(self.MOLECULAR_ASSIGNMENTS, list):
+            self.MOLECULAR_ASSIGNMENTS = [self.MOLECULAR_ASSIGNMENTS] if self.MOLECULAR_ASSIGNMENTS is not None else []
+        self.MOLECULAR_ASSIGNMENTS = [v if isinstance(v, MolecularAssignment) else MolecularAssignment(**as_dict(v)) for v in self.MOLECULAR_ASSIGNMENTS]
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass(repr=False)
+class CoreFileAttributes(YAMLRoot):
+    """
+    Universal attributes that apply to all file-based data in HTAN
+    """
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = HTAN["CoreFileAttributes"]
+    class_class_curie: ClassVar[str] = "htan:CoreFileAttributes"
+    class_name: ClassVar[str] = "CoreFileAttributes"
+    class_model_uri: ClassVar[URIRef] = HTAN.CoreFileAttributes
+
+    HTAN_DATA_FILE_ID: Union[str, CoreFileAttributesHTANDATAFILEID] = None
+    FILENAME: str = None
+    FILE_FORMAT: str = None
+    HTAN_PARENT_ID: Union[str, List[str]] = None
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self._is_empty(self.HTAN_DATA_FILE_ID):
+            self.MissingRequiredField("HTAN_DATA_FILE_ID")
+        if not isinstance(self.HTAN_DATA_FILE_ID, CoreFileAttributesHTANDATAFILEID):
+            self.HTAN_DATA_FILE_ID = CoreFileAttributesHTANDATAFILEID(self.HTAN_DATA_FILE_ID)
+
+        if self._is_empty(self.FILENAME):
+            self.MissingRequiredField("FILENAME")
+        if not isinstance(self.FILENAME, str):
+            self.FILENAME = str(self.FILENAME)
+
+        if self._is_empty(self.FILE_FORMAT):
+            self.MissingRequiredField("FILE_FORMAT")
+        if not isinstance(self.FILE_FORMAT, str):
+            self.FILE_FORMAT = str(self.FILE_FORMAT)
+
+        if self._is_empty(self.HTAN_PARENT_ID):
+            self.MissingRequiredField("HTAN_PARENT_ID")
+        if not isinstance(self.HTAN_PARENT_ID, list):
+            self.HTAN_PARENT_ID = [self.HTAN_PARENT_ID] if self.HTAN_PARENT_ID is not None else []
+        self.HTAN_PARENT_ID = [v if isinstance(v, str) else str(v) for v in self.HTAN_PARENT_ID]
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass(repr=False)
+class MassSpectrometryImagingLevel1(CoreFileAttributes):
+    """
+    Level 1 raw spectral data - continuous (profile) imzML acquisition annotations. The paired .ibd binary is an
+    unannotated companion carrying only CoreFileAttributes.
+    """
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = HTAN["MassSpectrometryImagingLevel1"]
+    class_class_curie: ClassVar[str] = "htan:MassSpectrometryImagingLevel1"
+    class_name: ClassVar[str] = "MassSpectrometryImagingLevel1"
+    class_model_uri: ClassVar[URIRef] = HTAN.MassSpectrometryImagingLevel1
+
+    HTAN_DATA_FILE_ID: Union[str, MassSpectrometryImagingLevel1HTANDATAFILEID] = None
+    HTAN_PARENT_ID: Union[str, List[str]] = None
+    FILE_FORMAT: str = None
+    FILENAME: str = None
+    MS_IONIZATION_TECHNIQUE: Union[str, "MsIonizationTechniqueEnum"] = None
+    MASS_ANALYZER_TYPE: Union[str, "MassAnalyzerTypeEnum"] = None
+    MASS_ANALYSIS_POLARITY: Union[str, "MassAnalysisPolarityEnum"] = None
+    ANALYTE_CLASS: Union[Union[str, "AnalyteClassEnum"], List[Union[str, "AnalyteClassEnum"]]] = None
+    IS_TARGETED: Union[bool, Bool] = None
+    ACQUISITION_INSTRUMENT_VENDOR: str = None
+    ACQUISITION_INSTRUMENT_MODEL: str = None
+    PIXEL_SIZE_X_UM: float = None
+    PIXEL_SIZE_Y_UM: float = None
+    MASS_TO_CHARGE_RANGE_LOW_VALUE: float = None
+    MASS_TO_CHARGE_RANGE_HIGH_VALUE: float = None
+    ION_MOBILITY: Union[bool, Bool] = None
+    SPECTRUM_TYPE: Union[str, "SpectrumTypeEnum"] = None
+    MASS_RESOLVING_POWER: int = None
+    MS_SCAN_MODE: Union[str, "MsScanModeEnum"] = None
+    CALIBRATION_TYPE: Union[str, "CalibrationTypeEnum"] = None
+    CALIBRANT_MASSES: str = None
+    TIME_SINCE_ACQUISITION_INSTRUMENT_CALIBRATION_VALUE: int = None
+    TIME_SINCE_ACQUISITION_INSTRUMENT_CALIBRATION_UNIT: Union[str, "TimeUnitEnum"] = None
+    SOFTWARE_AND_VERSION: str = None
+    IBD_FILE_UUID: str = None
+    PASSED_QC: Union[bool, Bool] = None
+    MASS_TO_CHARGE_RESOLVING_POWER: Optional[float] = None
+    PROTOCOL_LINK: Optional[str] = None
+    PREPARATION_MATRIX: Optional[Union[str, "PreparationMatrixEnum"]] = None
+    MATRIX_DEPOSITION_METHOD: Optional[Union[str, "MatrixDepositionMethodEnum"]] = None
+    PREPARATION_INSTRUMENT_VENDOR: Optional[str] = None
+    PREPARATION_INSTRUMENT_MODEL: Optional[str] = None
+    ANALYTE_ACQUISITION_ORDER: Optional[int] = None
+    PRE_ACQUISITION_TREATMENT: Optional[Union[str, "PreAcquisitionTreatmentEnum"]] = None
+    QC_COMMENT: Optional[str] = None
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self._is_empty(self.HTAN_DATA_FILE_ID):
+            self.MissingRequiredField("HTAN_DATA_FILE_ID")
+        if not isinstance(self.HTAN_DATA_FILE_ID, MassSpectrometryImagingLevel1HTANDATAFILEID):
+            self.HTAN_DATA_FILE_ID = MassSpectrometryImagingLevel1HTANDATAFILEID(self.HTAN_DATA_FILE_ID)
+
+        if self._is_empty(self.FILE_FORMAT):
+            self.MissingRequiredField("FILE_FORMAT")
+        if not isinstance(self.FILE_FORMAT, str):
+            self.FILE_FORMAT = str(self.FILE_FORMAT)
+
+        if self._is_empty(self.FILENAME):
+            self.MissingRequiredField("FILENAME")
+        if not isinstance(self.FILENAME, str):
+            self.FILENAME = str(self.FILENAME)
+
+        if self._is_empty(self.MS_IONIZATION_TECHNIQUE):
+            self.MissingRequiredField("MS_IONIZATION_TECHNIQUE")
+        if not isinstance(self.MS_IONIZATION_TECHNIQUE, MsIonizationTechniqueEnum):
+            self.MS_IONIZATION_TECHNIQUE = MsIonizationTechniqueEnum(self.MS_IONIZATION_TECHNIQUE)
+
+        if self._is_empty(self.MASS_ANALYZER_TYPE):
+            self.MissingRequiredField("MASS_ANALYZER_TYPE")
+        if not isinstance(self.MASS_ANALYZER_TYPE, MassAnalyzerTypeEnum):
+            self.MASS_ANALYZER_TYPE = MassAnalyzerTypeEnum(self.MASS_ANALYZER_TYPE)
+
+        if self._is_empty(self.MASS_ANALYSIS_POLARITY):
+            self.MissingRequiredField("MASS_ANALYSIS_POLARITY")
+        if not isinstance(self.MASS_ANALYSIS_POLARITY, MassAnalysisPolarityEnum):
+            self.MASS_ANALYSIS_POLARITY = MassAnalysisPolarityEnum(self.MASS_ANALYSIS_POLARITY)
+
+        if self._is_empty(self.ANALYTE_CLASS):
+            self.MissingRequiredField("ANALYTE_CLASS")
+        if not isinstance(self.ANALYTE_CLASS, list):
+            self.ANALYTE_CLASS = [self.ANALYTE_CLASS] if self.ANALYTE_CLASS is not None else []
+        self.ANALYTE_CLASS = [v if isinstance(v, AnalyteClassEnum) else AnalyteClassEnum(v) for v in self.ANALYTE_CLASS]
+
+        if self._is_empty(self.IS_TARGETED):
+            self.MissingRequiredField("IS_TARGETED")
+        if not isinstance(self.IS_TARGETED, Bool):
+            self.IS_TARGETED = Bool(self.IS_TARGETED)
+
+        if self._is_empty(self.ACQUISITION_INSTRUMENT_VENDOR):
+            self.MissingRequiredField("ACQUISITION_INSTRUMENT_VENDOR")
+        if not isinstance(self.ACQUISITION_INSTRUMENT_VENDOR, str):
+            self.ACQUISITION_INSTRUMENT_VENDOR = str(self.ACQUISITION_INSTRUMENT_VENDOR)
+
+        if self._is_empty(self.ACQUISITION_INSTRUMENT_MODEL):
+            self.MissingRequiredField("ACQUISITION_INSTRUMENT_MODEL")
+        if not isinstance(self.ACQUISITION_INSTRUMENT_MODEL, str):
+            self.ACQUISITION_INSTRUMENT_MODEL = str(self.ACQUISITION_INSTRUMENT_MODEL)
+
+        if self._is_empty(self.PIXEL_SIZE_X_UM):
+            self.MissingRequiredField("PIXEL_SIZE_X_UM")
+        if not isinstance(self.PIXEL_SIZE_X_UM, float):
+            self.PIXEL_SIZE_X_UM = float(self.PIXEL_SIZE_X_UM)
+
+        if self._is_empty(self.PIXEL_SIZE_Y_UM):
+            self.MissingRequiredField("PIXEL_SIZE_Y_UM")
+        if not isinstance(self.PIXEL_SIZE_Y_UM, float):
+            self.PIXEL_SIZE_Y_UM = float(self.PIXEL_SIZE_Y_UM)
+
+        if self._is_empty(self.MASS_TO_CHARGE_RANGE_LOW_VALUE):
+            self.MissingRequiredField("MASS_TO_CHARGE_RANGE_LOW_VALUE")
+        if not isinstance(self.MASS_TO_CHARGE_RANGE_LOW_VALUE, float):
+            self.MASS_TO_CHARGE_RANGE_LOW_VALUE = float(self.MASS_TO_CHARGE_RANGE_LOW_VALUE)
+
+        if self._is_empty(self.MASS_TO_CHARGE_RANGE_HIGH_VALUE):
+            self.MissingRequiredField("MASS_TO_CHARGE_RANGE_HIGH_VALUE")
+        if not isinstance(self.MASS_TO_CHARGE_RANGE_HIGH_VALUE, float):
+            self.MASS_TO_CHARGE_RANGE_HIGH_VALUE = float(self.MASS_TO_CHARGE_RANGE_HIGH_VALUE)
+
+        if self._is_empty(self.ION_MOBILITY):
+            self.MissingRequiredField("ION_MOBILITY")
+        if not isinstance(self.ION_MOBILITY, Bool):
+            self.ION_MOBILITY = Bool(self.ION_MOBILITY)
+
+        if self._is_empty(self.SPECTRUM_TYPE):
+            self.MissingRequiredField("SPECTRUM_TYPE")
+        if not isinstance(self.SPECTRUM_TYPE, SpectrumTypeEnum):
+            self.SPECTRUM_TYPE = SpectrumTypeEnum(self.SPECTRUM_TYPE)
+
+        if self._is_empty(self.MASS_RESOLVING_POWER):
+            self.MissingRequiredField("MASS_RESOLVING_POWER")
+        if not isinstance(self.MASS_RESOLVING_POWER, int):
+            self.MASS_RESOLVING_POWER = int(self.MASS_RESOLVING_POWER)
+
+        if self._is_empty(self.MS_SCAN_MODE):
+            self.MissingRequiredField("MS_SCAN_MODE")
+        if not isinstance(self.MS_SCAN_MODE, MsScanModeEnum):
+            self.MS_SCAN_MODE = MsScanModeEnum(self.MS_SCAN_MODE)
+
+        if self._is_empty(self.CALIBRATION_TYPE):
+            self.MissingRequiredField("CALIBRATION_TYPE")
+        if not isinstance(self.CALIBRATION_TYPE, CalibrationTypeEnum):
+            self.CALIBRATION_TYPE = CalibrationTypeEnum(self.CALIBRATION_TYPE)
+
+        if self._is_empty(self.CALIBRANT_MASSES):
+            self.MissingRequiredField("CALIBRANT_MASSES")
+        if not isinstance(self.CALIBRANT_MASSES, str):
+            self.CALIBRANT_MASSES = str(self.CALIBRANT_MASSES)
+
+        if self._is_empty(self.TIME_SINCE_ACQUISITION_INSTRUMENT_CALIBRATION_VALUE):
+            self.MissingRequiredField("TIME_SINCE_ACQUISITION_INSTRUMENT_CALIBRATION_VALUE")
+        if not isinstance(self.TIME_SINCE_ACQUISITION_INSTRUMENT_CALIBRATION_VALUE, int):
+            self.TIME_SINCE_ACQUISITION_INSTRUMENT_CALIBRATION_VALUE = int(self.TIME_SINCE_ACQUISITION_INSTRUMENT_CALIBRATION_VALUE)
+
+        if self._is_empty(self.TIME_SINCE_ACQUISITION_INSTRUMENT_CALIBRATION_UNIT):
+            self.MissingRequiredField("TIME_SINCE_ACQUISITION_INSTRUMENT_CALIBRATION_UNIT")
+        if not isinstance(self.TIME_SINCE_ACQUISITION_INSTRUMENT_CALIBRATION_UNIT, TimeUnitEnum):
+            self.TIME_SINCE_ACQUISITION_INSTRUMENT_CALIBRATION_UNIT = TimeUnitEnum(self.TIME_SINCE_ACQUISITION_INSTRUMENT_CALIBRATION_UNIT)
+
+        if self._is_empty(self.SOFTWARE_AND_VERSION):
+            self.MissingRequiredField("SOFTWARE_AND_VERSION")
+        if not isinstance(self.SOFTWARE_AND_VERSION, str):
+            self.SOFTWARE_AND_VERSION = str(self.SOFTWARE_AND_VERSION)
+
+        if self._is_empty(self.IBD_FILE_UUID):
+            self.MissingRequiredField("IBD_FILE_UUID")
+        if not isinstance(self.IBD_FILE_UUID, str):
+            self.IBD_FILE_UUID = str(self.IBD_FILE_UUID)
+
+        if self._is_empty(self.PASSED_QC):
+            self.MissingRequiredField("PASSED_QC")
+        if not isinstance(self.PASSED_QC, Bool):
+            self.PASSED_QC = Bool(self.PASSED_QC)
+
+        if self.MASS_TO_CHARGE_RESOLVING_POWER is not None and not isinstance(self.MASS_TO_CHARGE_RESOLVING_POWER, float):
+            self.MASS_TO_CHARGE_RESOLVING_POWER = float(self.MASS_TO_CHARGE_RESOLVING_POWER)
+
+        if self.PROTOCOL_LINK is not None and not isinstance(self.PROTOCOL_LINK, str):
+            self.PROTOCOL_LINK = str(self.PROTOCOL_LINK)
+
+        if self.PREPARATION_MATRIX is not None and not isinstance(self.PREPARATION_MATRIX, PreparationMatrixEnum):
+            self.PREPARATION_MATRIX = PreparationMatrixEnum(self.PREPARATION_MATRIX)
+
+        if self.MATRIX_DEPOSITION_METHOD is not None and not isinstance(self.MATRIX_DEPOSITION_METHOD, MatrixDepositionMethodEnum):
+            self.MATRIX_DEPOSITION_METHOD = MatrixDepositionMethodEnum(self.MATRIX_DEPOSITION_METHOD)
+
+        if self.PREPARATION_INSTRUMENT_VENDOR is not None and not isinstance(self.PREPARATION_INSTRUMENT_VENDOR, str):
+            self.PREPARATION_INSTRUMENT_VENDOR = str(self.PREPARATION_INSTRUMENT_VENDOR)
+
+        if self.PREPARATION_INSTRUMENT_MODEL is not None and not isinstance(self.PREPARATION_INSTRUMENT_MODEL, str):
+            self.PREPARATION_INSTRUMENT_MODEL = str(self.PREPARATION_INSTRUMENT_MODEL)
+
+        if self.ANALYTE_ACQUISITION_ORDER is not None and not isinstance(self.ANALYTE_ACQUISITION_ORDER, int):
+            self.ANALYTE_ACQUISITION_ORDER = int(self.ANALYTE_ACQUISITION_ORDER)
+
+        if self.PRE_ACQUISITION_TREATMENT is not None and not isinstance(self.PRE_ACQUISITION_TREATMENT, PreAcquisitionTreatmentEnum):
+            self.PRE_ACQUISITION_TREATMENT = PreAcquisitionTreatmentEnum(self.PRE_ACQUISITION_TREATMENT)
+
+        if self.QC_COMMENT is not None and not isinstance(self.QC_COMMENT, str):
+            self.QC_COMMENT = str(self.QC_COMMENT)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass(repr=False)
+class MassSpectrometryImagingLevel2(CoreFileAttributes):
+    """
+    Level 2 processed spectral data - centroided imzML after baseline correction, peak picking, mass alignment, and
+    normalization. The paired .ibd binary is an unannotated companion.
+    """
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = HTAN["MassSpectrometryImagingLevel2"]
+    class_class_curie: ClassVar[str] = "htan:MassSpectrometryImagingLevel2"
+    class_name: ClassVar[str] = "MassSpectrometryImagingLevel2"
+    class_model_uri: ClassVar[URIRef] = HTAN.MassSpectrometryImagingLevel2
+
+    HTAN_DATA_FILE_ID: Union[str, MassSpectrometryImagingLevel2HTANDATAFILEID] = None
+    HTAN_PARENT_ID: Union[str, List[str]] = None
+    FILE_FORMAT: str = None
+    FILENAME: str = None
+    SOFTWARE_AND_VERSION: str = None
+    BASELINE_CORRECTION_METHOD: Union[str, "BaselineCorrectionMethodEnum"] = None
+    PEAK_PICKING_METHOD: str = None
+    PEAK_PICKING_SNR_THRESHOLD: float = None
+    NORMALIZATION_METHOD: Union[str, "NormalizationMethodEnum"] = None
+    MASS_ALIGNMENT_METHOD: str = None
+    MASS_TOLERANCE_PPM: float = None
+    MEDIAN_TIC: float = None
+    TIC_CV: float = None
+    MASS_ACCURACY_PPM: float = None
+    PIXEL_COMPLETION_RATE: float = None
+    NUM_DETECTED_PEAKS: int = None
+    PASSED_QC: Union[bool, Bool] = None
+    SMOOTHING_METHOD: Optional[Union[str, "SmoothingMethodEnum"]] = None
+    PROTOCOL_LINK: Optional[str] = None
+    QC_COMMENT: Optional[str] = None
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self._is_empty(self.HTAN_DATA_FILE_ID):
+            self.MissingRequiredField("HTAN_DATA_FILE_ID")
+        if not isinstance(self.HTAN_DATA_FILE_ID, MassSpectrometryImagingLevel2HTANDATAFILEID):
+            self.HTAN_DATA_FILE_ID = MassSpectrometryImagingLevel2HTANDATAFILEID(self.HTAN_DATA_FILE_ID)
+
+        if self._is_empty(self.FILE_FORMAT):
+            self.MissingRequiredField("FILE_FORMAT")
+        if not isinstance(self.FILE_FORMAT, str):
+            self.FILE_FORMAT = str(self.FILE_FORMAT)
+
+        if self._is_empty(self.FILENAME):
+            self.MissingRequiredField("FILENAME")
+        if not isinstance(self.FILENAME, str):
+            self.FILENAME = str(self.FILENAME)
+
+        if self._is_empty(self.SOFTWARE_AND_VERSION):
+            self.MissingRequiredField("SOFTWARE_AND_VERSION")
+        if not isinstance(self.SOFTWARE_AND_VERSION, str):
+            self.SOFTWARE_AND_VERSION = str(self.SOFTWARE_AND_VERSION)
+
+        if self._is_empty(self.BASELINE_CORRECTION_METHOD):
+            self.MissingRequiredField("BASELINE_CORRECTION_METHOD")
+        if not isinstance(self.BASELINE_CORRECTION_METHOD, BaselineCorrectionMethodEnum):
+            self.BASELINE_CORRECTION_METHOD = BaselineCorrectionMethodEnum(self.BASELINE_CORRECTION_METHOD)
+
+        if self._is_empty(self.PEAK_PICKING_METHOD):
+            self.MissingRequiredField("PEAK_PICKING_METHOD")
+        if not isinstance(self.PEAK_PICKING_METHOD, str):
+            self.PEAK_PICKING_METHOD = str(self.PEAK_PICKING_METHOD)
+
+        if self._is_empty(self.PEAK_PICKING_SNR_THRESHOLD):
+            self.MissingRequiredField("PEAK_PICKING_SNR_THRESHOLD")
+        if not isinstance(self.PEAK_PICKING_SNR_THRESHOLD, float):
+            self.PEAK_PICKING_SNR_THRESHOLD = float(self.PEAK_PICKING_SNR_THRESHOLD)
+
+        if self._is_empty(self.NORMALIZATION_METHOD):
+            self.MissingRequiredField("NORMALIZATION_METHOD")
+        if not isinstance(self.NORMALIZATION_METHOD, NormalizationMethodEnum):
+            self.NORMALIZATION_METHOD = NormalizationMethodEnum(self.NORMALIZATION_METHOD)
+
+        if self._is_empty(self.MASS_ALIGNMENT_METHOD):
+            self.MissingRequiredField("MASS_ALIGNMENT_METHOD")
+        if not isinstance(self.MASS_ALIGNMENT_METHOD, str):
+            self.MASS_ALIGNMENT_METHOD = str(self.MASS_ALIGNMENT_METHOD)
+
+        if self._is_empty(self.MASS_TOLERANCE_PPM):
+            self.MissingRequiredField("MASS_TOLERANCE_PPM")
+        if not isinstance(self.MASS_TOLERANCE_PPM, float):
+            self.MASS_TOLERANCE_PPM = float(self.MASS_TOLERANCE_PPM)
+
+        if self._is_empty(self.MEDIAN_TIC):
+            self.MissingRequiredField("MEDIAN_TIC")
+        if not isinstance(self.MEDIAN_TIC, float):
+            self.MEDIAN_TIC = float(self.MEDIAN_TIC)
+
+        if self._is_empty(self.TIC_CV):
+            self.MissingRequiredField("TIC_CV")
+        if not isinstance(self.TIC_CV, float):
+            self.TIC_CV = float(self.TIC_CV)
+
+        if self._is_empty(self.MASS_ACCURACY_PPM):
+            self.MissingRequiredField("MASS_ACCURACY_PPM")
+        if not isinstance(self.MASS_ACCURACY_PPM, float):
+            self.MASS_ACCURACY_PPM = float(self.MASS_ACCURACY_PPM)
+
+        if self._is_empty(self.PIXEL_COMPLETION_RATE):
+            self.MissingRequiredField("PIXEL_COMPLETION_RATE")
+        if not isinstance(self.PIXEL_COMPLETION_RATE, float):
+            self.PIXEL_COMPLETION_RATE = float(self.PIXEL_COMPLETION_RATE)
+
+        if self._is_empty(self.NUM_DETECTED_PEAKS):
+            self.MissingRequiredField("NUM_DETECTED_PEAKS")
+        if not isinstance(self.NUM_DETECTED_PEAKS, int):
+            self.NUM_DETECTED_PEAKS = int(self.NUM_DETECTED_PEAKS)
+
+        if self._is_empty(self.PASSED_QC):
+            self.MissingRequiredField("PASSED_QC")
+        if not isinstance(self.PASSED_QC, Bool):
+            self.PASSED_QC = Bool(self.PASSED_QC)
+
+        if self.SMOOTHING_METHOD is not None and not isinstance(self.SMOOTHING_METHOD, SmoothingMethodEnum):
+            self.SMOOTHING_METHOD = SmoothingMethodEnum(self.SMOOTHING_METHOD)
+
+        if self.PROTOCOL_LINK is not None and not isinstance(self.PROTOCOL_LINK, str):
+            self.PROTOCOL_LINK = str(self.PROTOCOL_LINK)
+
+        if self.QC_COMMENT is not None and not isinstance(self.QC_COMMENT, str):
+            self.QC_COMMENT = str(self.QC_COMMENT)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass(repr=False)
+class MassSpectrometryImagingLevel3(CoreFileAttributes):
+    """
+    Level 3 annotation-filtered OME-TIFF. Channels include only annotated m/z values plus biologically relevant
+    unknowns. Per-channel molecular detail is carried by the companion Molecular Assignments RecordSet.
+    """
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = HTAN["MassSpectrometryImagingLevel3"]
+    class_class_curie: ClassVar[str] = "htan:MassSpectrometryImagingLevel3"
+    class_name: ClassVar[str] = "MassSpectrometryImagingLevel3"
+    class_model_uri: ClassVar[URIRef] = HTAN.MassSpectrometryImagingLevel3
+
+    HTAN_DATA_FILE_ID: Union[str, MassSpectrometryImagingLevel3HTANDATAFILEID] = None
+    HTAN_PARENT_ID: Union[str, List[str]] = None
+    FILE_FORMAT: str = None
+    FILENAME: str = None
+    NUM_ANNOTATED_CHANNELS: int = None
+    NUM_UNKNOWN_CHANNELS: int = None
+    SOFTWARE_AND_VERSION: str = None
+    PASSED_QC: Union[bool, Bool] = None
+    PROTOCOL_LINK: Optional[str] = None
+    QC_COMMENT: Optional[str] = None
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self._is_empty(self.HTAN_DATA_FILE_ID):
+            self.MissingRequiredField("HTAN_DATA_FILE_ID")
+        if not isinstance(self.HTAN_DATA_FILE_ID, MassSpectrometryImagingLevel3HTANDATAFILEID):
+            self.HTAN_DATA_FILE_ID = MassSpectrometryImagingLevel3HTANDATAFILEID(self.HTAN_DATA_FILE_ID)
+
+        if self._is_empty(self.FILE_FORMAT):
+            self.MissingRequiredField("FILE_FORMAT")
+        if not isinstance(self.FILE_FORMAT, str):
+            self.FILE_FORMAT = str(self.FILE_FORMAT)
+
+        if self._is_empty(self.FILENAME):
+            self.MissingRequiredField("FILENAME")
+        if not isinstance(self.FILENAME, str):
+            self.FILENAME = str(self.FILENAME)
+
+        if self._is_empty(self.NUM_ANNOTATED_CHANNELS):
+            self.MissingRequiredField("NUM_ANNOTATED_CHANNELS")
+        if not isinstance(self.NUM_ANNOTATED_CHANNELS, int):
+            self.NUM_ANNOTATED_CHANNELS = int(self.NUM_ANNOTATED_CHANNELS)
+
+        if self._is_empty(self.NUM_UNKNOWN_CHANNELS):
+            self.MissingRequiredField("NUM_UNKNOWN_CHANNELS")
+        if not isinstance(self.NUM_UNKNOWN_CHANNELS, int):
+            self.NUM_UNKNOWN_CHANNELS = int(self.NUM_UNKNOWN_CHANNELS)
+
+        if self._is_empty(self.SOFTWARE_AND_VERSION):
+            self.MissingRequiredField("SOFTWARE_AND_VERSION")
+        if not isinstance(self.SOFTWARE_AND_VERSION, str):
+            self.SOFTWARE_AND_VERSION = str(self.SOFTWARE_AND_VERSION)
+
+        if self._is_empty(self.PASSED_QC):
+            self.MissingRequiredField("PASSED_QC")
+        if not isinstance(self.PASSED_QC, Bool):
+            self.PASSED_QC = Bool(self.PASSED_QC)
+
+        if self.PROTOCOL_LINK is not None and not isinstance(self.PROTOCOL_LINK, str):
+            self.PROTOCOL_LINK = str(self.PROTOCOL_LINK)
+
+        if self.QC_COMMENT is not None and not isinstance(self.QC_COMMENT, str):
+            self.QC_COMMENT = str(self.QC_COMMENT)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass(repr=False)
+class MassSpectrometryImagingLevel4(CoreFileAttributes):
+    """
+    Level 4 segmented and region/cell-type quantified output (optional). Includes a segmentation mask OME-TIFF and/or
+    a region quantification table.
+    """
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = HTAN["MassSpectrometryImagingLevel4"]
+    class_class_curie: ClassVar[str] = "htan:MassSpectrometryImagingLevel4"
+    class_name: ClassVar[str] = "MassSpectrometryImagingLevel4"
+    class_model_uri: ClassVar[URIRef] = HTAN.MassSpectrometryImagingLevel4
+
+    HTAN_DATA_FILE_ID: Union[str, MassSpectrometryImagingLevel4HTANDATAFILEID] = None
+    HTAN_PARENT_ID: Union[str, List[str]] = None
+    FILE_FORMAT: str = None
+    FILENAME: str = None
+    SEGMENTATION_METHOD: str = None
+    SEGMENTATION_CLASS_COUNT: int = None
+    SEGMENTATION_REFERENCE_MODALITY: Union[str, "SegmentationReferenceModalityEnum"] = None
+    PASSED_QC: Union[bool, Bool] = None
+    QC_COMMENT: Optional[str] = None
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self._is_empty(self.HTAN_DATA_FILE_ID):
+            self.MissingRequiredField("HTAN_DATA_FILE_ID")
+        if not isinstance(self.HTAN_DATA_FILE_ID, MassSpectrometryImagingLevel4HTANDATAFILEID):
+            self.HTAN_DATA_FILE_ID = MassSpectrometryImagingLevel4HTANDATAFILEID(self.HTAN_DATA_FILE_ID)
+
+        if self._is_empty(self.FILE_FORMAT):
+            self.MissingRequiredField("FILE_FORMAT")
+        if not isinstance(self.FILE_FORMAT, str):
+            self.FILE_FORMAT = str(self.FILE_FORMAT)
+
+        if self._is_empty(self.FILENAME):
+            self.MissingRequiredField("FILENAME")
+        if not isinstance(self.FILENAME, str):
+            self.FILENAME = str(self.FILENAME)
+
+        if self._is_empty(self.SEGMENTATION_METHOD):
+            self.MissingRequiredField("SEGMENTATION_METHOD")
+        if not isinstance(self.SEGMENTATION_METHOD, str):
+            self.SEGMENTATION_METHOD = str(self.SEGMENTATION_METHOD)
+
+        if self._is_empty(self.SEGMENTATION_CLASS_COUNT):
+            self.MissingRequiredField("SEGMENTATION_CLASS_COUNT")
+        if not isinstance(self.SEGMENTATION_CLASS_COUNT, int):
+            self.SEGMENTATION_CLASS_COUNT = int(self.SEGMENTATION_CLASS_COUNT)
+
+        if self._is_empty(self.SEGMENTATION_REFERENCE_MODALITY):
+            self.MissingRequiredField("SEGMENTATION_REFERENCE_MODALITY")
+        if not isinstance(self.SEGMENTATION_REFERENCE_MODALITY, SegmentationReferenceModalityEnum):
+            self.SEGMENTATION_REFERENCE_MODALITY = SegmentationReferenceModalityEnum(self.SEGMENTATION_REFERENCE_MODALITY)
+
+        if self._is_empty(self.PASSED_QC):
+            self.MissingRequiredField("PASSED_QC")
+        if not isinstance(self.PASSED_QC, Bool):
+            self.PASSED_QC = Bool(self.PASSED_QC)
+
+        if self.QC_COMMENT is not None and not isinstance(self.QC_COMMENT, str):
+            self.QC_COMMENT = str(self.QC_COMMENT)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass(repr=False)
+class MolecularAssignment(YAMLRoot):
+    """
+    A single molecular assignment row corresponding to one OME-TIFF channel in a Level 3 file. The unique row key is
+    (HTAN_DATA_FILE_ID, CHANNEL_INDEX). Channel count must equal RecordSet row count (enforced by the DCC validator).
+    """
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = HTAN["MolecularAssignment"]
+    class_class_curie: ClassVar[str] = "htan:MolecularAssignment"
+    class_name: ClassVar[str] = "MolecularAssignment"
+    class_model_uri: ClassVar[URIRef] = HTAN.MolecularAssignment
+
+    HTAN_DATA_FILE_ID: str = None
+    CHANNEL_INDEX: int = None
+    MZ_OBSERVED: float = None
+    MOLECULAR_NAME: str = None
+    SOFTWARE_AND_VERSION: str = None
+    CONFIDENCE_LEVEL: int = None
+    EVIDENCE_TYPE: Union[Union[str, "EvidenceTypeEnum"], List[Union[str, "EvidenceTypeEnum"]]] = None
+    MZ_THEORETICAL: Optional[float] = None
+    MASS_ERROR_PPM: Optional[float] = None
+    MOLECULAR_FORMULA: Optional[str] = None
+    ADDUCT: Optional[Union[str, "AdductEnum"]] = None
+    DATABASE_SOURCE: Optional[Union[str, "DatabaseSourceEnum"]] = None
+    DATABASE_ID: Optional[str] = None
+    DATABASE_VERSION: Optional[str] = None
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self._is_empty(self.HTAN_DATA_FILE_ID):
+            self.MissingRequiredField("HTAN_DATA_FILE_ID")
+        if not isinstance(self.HTAN_DATA_FILE_ID, str):
+            self.HTAN_DATA_FILE_ID = str(self.HTAN_DATA_FILE_ID)
+
+        if self._is_empty(self.CHANNEL_INDEX):
+            self.MissingRequiredField("CHANNEL_INDEX")
+        if not isinstance(self.CHANNEL_INDEX, int):
+            self.CHANNEL_INDEX = int(self.CHANNEL_INDEX)
+
+        if self._is_empty(self.MZ_OBSERVED):
+            self.MissingRequiredField("MZ_OBSERVED")
+        if not isinstance(self.MZ_OBSERVED, float):
+            self.MZ_OBSERVED = float(self.MZ_OBSERVED)
+
+        if self._is_empty(self.MOLECULAR_NAME):
+            self.MissingRequiredField("MOLECULAR_NAME")
+        if not isinstance(self.MOLECULAR_NAME, str):
+            self.MOLECULAR_NAME = str(self.MOLECULAR_NAME)
+
+        if self._is_empty(self.SOFTWARE_AND_VERSION):
+            self.MissingRequiredField("SOFTWARE_AND_VERSION")
+        if not isinstance(self.SOFTWARE_AND_VERSION, str):
+            self.SOFTWARE_AND_VERSION = str(self.SOFTWARE_AND_VERSION)
+
+        if self._is_empty(self.CONFIDENCE_LEVEL):
+            self.MissingRequiredField("CONFIDENCE_LEVEL")
+        if not isinstance(self.CONFIDENCE_LEVEL, int):
+            self.CONFIDENCE_LEVEL = int(self.CONFIDENCE_LEVEL)
+
+        if self._is_empty(self.EVIDENCE_TYPE):
+            self.MissingRequiredField("EVIDENCE_TYPE")
+        if not isinstance(self.EVIDENCE_TYPE, list):
+            self.EVIDENCE_TYPE = [self.EVIDENCE_TYPE] if self.EVIDENCE_TYPE is not None else []
+        self.EVIDENCE_TYPE = [v if isinstance(v, EvidenceTypeEnum) else EvidenceTypeEnum(v) for v in self.EVIDENCE_TYPE]
+
+        if self.MZ_THEORETICAL is not None and not isinstance(self.MZ_THEORETICAL, float):
+            self.MZ_THEORETICAL = float(self.MZ_THEORETICAL)
+
+        if self.MASS_ERROR_PPM is not None and not isinstance(self.MASS_ERROR_PPM, float):
+            self.MASS_ERROR_PPM = float(self.MASS_ERROR_PPM)
+
+        if self.MOLECULAR_FORMULA is not None and not isinstance(self.MOLECULAR_FORMULA, str):
+            self.MOLECULAR_FORMULA = str(self.MOLECULAR_FORMULA)
+
+        if self.ADDUCT is not None and not isinstance(self.ADDUCT, AdductEnum):
+            self.ADDUCT = AdductEnum(self.ADDUCT)
+
+        if self.DATABASE_SOURCE is not None and not isinstance(self.DATABASE_SOURCE, DatabaseSourceEnum):
+            self.DATABASE_SOURCE = DatabaseSourceEnum(self.DATABASE_SOURCE)
+
+        if self.DATABASE_ID is not None and not isinstance(self.DATABASE_ID, str):
+            self.DATABASE_ID = str(self.DATABASE_ID)
+
+        if self.DATABASE_VERSION is not None and not isinstance(self.DATABASE_VERSION, str):
+            self.DATABASE_VERSION = str(self.DATABASE_VERSION)
+
+        super().__post_init__(**kwargs)
+
+
+# Enumerations
+class MsIonizationTechniqueEnum(EnumDefinitionImpl):
+
+    DESI = PermissibleValue(
+        text="DESI",
+        description="Desorption Electrospray Ionization - ambient spray ionization")
+    IR_MALDESI = PermissibleValue(
+        text="IR_MALDESI",
+        description="Infrared MALDESI - IR laser ablation coupled with electrospray")
+    MALDI = PermissibleValue(
+        text="MALDI",
+        description="Matrix-Assisted Laser Desorption/Ionization")
+    MALDI_2 = PermissibleValue(
+        text="MALDI_2",
+        description="""MALDI with secondary post-ionization laser for enhanced sensitivity (Bruker timsTOF Flex MALDI-2 mode)""")
+    OTHER = PermissibleValue(
+        text="OTHER",
+        description="Ionization technique not listed; describe in PROTOCOL_LINK")
+    SIMS = PermissibleValue(
+        text="SIMS",
+        description="Secondary Ion Mass Spectrometry - ion beam sputtering for sub-micron resolution")
+
+    _defn = EnumDefinition(
+        name="MsIonizationTechniqueEnum",
+    )
+
+class MassAnalyzerTypeEnum(EnumDefinitionImpl):
+
+    FTICR = PermissibleValue(
+        text="FTICR",
+        description="Fourier-Transform Ion Cyclotron Resonance")
+    ION_TRAP = PermissibleValue(
+        text="ION_TRAP",
+        description="Ion trap (linear or 3D)")
+    ORBITRAP = PermissibleValue(
+        text="ORBITRAP",
+        description="Orbitrap electrostatic trap (Thermo)")
+    OTHER = PermissibleValue(
+        text="OTHER",
+        description="Analyser type not listed")
+    Q_TOF = PermissibleValue(
+        text="Q_TOF",
+        description="Quadrupole Time-of-Flight hybrid")
+    TOF = PermissibleValue(
+        text="TOF",
+        description="Time-of-Flight mass analyser")
+    TRIPLE_QUADRUPOLE = PermissibleValue(
+        text="TRIPLE_QUADRUPOLE",
+        description="Triple-quadrupole (tandem MS)")
+
+    _defn = EnumDefinition(
+        name="MassAnalyzerTypeEnum",
+    )
+
+class MassAnalysisPolarityEnum(EnumDefinitionImpl):
+
+    BOTH = PermissibleValue(
+        text="BOTH",
+        description="""Dataset contains both positive and negative mode acquisitions (HTAN extension - not present in HuBMAP)""")
+    NEG = PermissibleValue(
+        text="NEG",
+        description="Negative ionisation mode")
+    POS = PermissibleValue(
+        text="POS",
+        description="Positive ionisation mode")
+
+    _defn = EnumDefinition(
+        name="MassAnalysisPolarityEnum",
+    )
+
+class AnalyteClassEnum(EnumDefinitionImpl):
+
+    GLYCANS = PermissibleValue(
+        text="GLYCANS",
+        description="N-linked or O-linked glycans (e.g., PNGaseF-released)")
+    LIPIDS = PermissibleValue(
+        text="LIPIDS",
+        description="Lipids and fatty acids")
+    METABOLITES = PermissibleValue(
+        text="METABOLITES",
+        description="Small-molecule metabolites (non-lipid)")
+    NUCLEIC_ACIDS = PermissibleValue(
+        text="NUCLEIC_ACIDS",
+        description="Oligonucleotides or nucleic acid species")
+    PEPTIDES = PermissibleValue(
+        text="PEPTIDES",
+        description="Tryptic or enzymatically generated peptides")
+    PHARMACEUTICALS = PermissibleValue(
+        text="PHARMACEUTICALS",
+        description="Drug compounds or their metabolites")
+    PROTEINS = PermissibleValue(
+        text="PROTEINS",
+        description="Intact or top-down proteins")
+
+    _defn = EnumDefinition(
+        name="AnalyteClassEnum",
+    )
+
+class SpectrumTypeEnum(EnumDefinitionImpl):
+
+    CENTROID = PermissibleValue(
+        text="CENTROID",
+        description="Peak-picked spectrum; discrete m/z-intensity pairs. Required at Level 2.")
+    PROFILE = PermissibleValue(
+        text="PROFILE",
+        description="Continuous spectrum; full peak shapes preserved. Required at Level 1.")
+
+    _defn = EnumDefinition(
+        name="SpectrumTypeEnum",
+    )
+
+class MsScanModeEnum(EnumDefinitionImpl):
+
+    LINEAR = PermissibleValue(
+        text="LINEAR",
+        description="Linear TOF mode; higher sensitivity for large molecules")
+    NOT_APPLICABLE = PermissibleValue(
+        text="NOT_APPLICABLE",
+        description="Analyser does not use a TOF scan mode (e.g., Orbitrap, FTICR, Q-TOF hybrid)")
+    OTHER = PermissibleValue(
+        text="OTHER",
+        description="Scan mode not listed")
+    REFLECTRON = PermissibleValue(
+        text="REFLECTRON",
+        description="Reflectron TOF mode; improved mass resolution via ion reflection")
+
+    _defn = EnumDefinition(
+        name="MsScanModeEnum",
+    )
+
+class CalibrationTypeEnum(EnumDefinitionImpl):
+
+    EXTERNAL = PermissibleValue(
+        text="EXTERNAL",
+        description="Calibration performed on a separate reference spot prior to acquisition")
+    INTERNAL = PermissibleValue(
+        text="INTERNAL",
+        description="Calibrant ions co-present in each spectrum during acquisition")
+    LOCK_MASS = PermissibleValue(
+        text="LOCK_MASS",
+        description="Real-time calibration correction using a reference ion of known m/z")
+
+    _defn = EnumDefinition(
+        name="CalibrationTypeEnum",
+    )
+
+class TimeUnitEnum(EnumDefinitionImpl):
+
+    DAYS = PermissibleValue(
+        text="DAYS",
+        description="Time expressed in days")
+    HOURS = PermissibleValue(
+        text="HOURS",
+        description="Time expressed in hours")
+
+    _defn = EnumDefinition(
+        name="TimeUnitEnum",
+    )
+
+class PreparationMatrixEnum(EnumDefinitionImpl):
+
+    CHCA = PermissibleValue(
+        text="CHCA",
+        description="alpha-Cyano-4-hydroxycinnamic acid; used for peptides and small proteins")
+    DAN = PermissibleValue(
+        text="DAN",
+        description="1,5-Diaminonaphthalene; used for lipids and metabolites in negative mode")
+    DHA = PermissibleValue(
+        text="DHA",
+        description="2,6-Dihydroxyacetophenone; used for oligonucleotides and acidic lipids")
+    DHB = PermissibleValue(
+        text="DHB",
+        description="2,5-Dihydroxybenzoic acid; used for lipids, oligosaccharides, and metabolites")
+    NOT_APPLICABLE = PermissibleValue(
+        text="NOT_APPLICABLE",
+        description="Ionization modality does not use a matrix (DESI, SIMS, IR-MALDESI)")
+    OTHER = PermissibleValue(
+        text="OTHER",
+        description="Matrix compound not listed; specify in PROTOCOL_LINK")
+    SA = PermissibleValue(
+        text="SA",
+        description="Sinapinic acid; used for intact proteins >10 kDa")
+
+    _defn = EnumDefinition(
+        name="PreparationMatrixEnum",
+    )
+
+    @classmethod
+    def _addvals(cls):
+        setattr(cls, "9_AA",
+            PermissibleValue(
+                text="9_AA",
+                description="9-Aminoacridine; used for lipids and metabolites in negative mode"))
+
+class MatrixDepositionMethodEnum(EnumDefinitionImpl):
+
+    ELECTROSPRAY = PermissibleValue(
+        text="ELECTROSPRAY",
+        description="Electrospray-based matrix deposition")
+    NOT_APPLICABLE = PermissibleValue(
+        text="NOT_APPLICABLE",
+        description="Ionization modality does not use a matrix")
+    PNEUMATIC_SPRAYER = PermissibleValue(
+        text="PNEUMATIC_SPRAYER",
+        description="Automated pneumatic spray coater (e.g., HTX TM-Sprayer)")
+    ROBOTIC_SPOTTER = PermissibleValue(
+        text="ROBOTIC_SPOTTER",
+        description="Robotic micro-dispensing of discrete matrix spots")
+    SPRAY = PermissibleValue(
+        text="SPRAY",
+        description="Pneumatic or manual aerosol spray application")
+    SUBLIMATION = PermissibleValue(
+        text="SUBLIMATION",
+        description="Thermal sublimation deposition for uniform crystal layer")
+
+    _defn = EnumDefinition(
+        name="MatrixDepositionMethodEnum",
+    )
+
+class PreAcquisitionTreatmentEnum(EnumDefinitionImpl):
+
+    NONE = PermissibleValue(
+        text="NONE",
+        description="No enzymatic or chemical treatment applied before this acquisition run")
+    OTHER = PermissibleValue(
+        text="OTHER",
+        description="Treatment not listed; describe in PROTOCOL_LINK")
+    PNGASEF = PermissibleValue(
+        text="PNGASEF",
+        description="PNGase F enzyme applied to release N-linked glycans from glycoproteins")
+    PNGASEF_THEN_TRYPSIN = PermissibleValue(
+        text="PNGASEF_THEN_TRYPSIN",
+        description="Sequential PNGase F followed by trypsin digestion")
+    TRYPSIN = PermissibleValue(
+        text="TRYPSIN",
+        description="Trypsin applied for in-tissue proteolytic digestion to generate peptides")
+
+    _defn = EnumDefinition(
+        name="PreAcquisitionTreatmentEnum",
+    )
+
+class BaselineCorrectionMethodEnum(EnumDefinitionImpl):
+
+    NONE = PermissibleValue(
+        text="NONE",
+        description="No baseline correction applied")
+    OTHER = PermissibleValue(
+        text="OTHER",
+        description="Algorithm not listed; specify in SOFTWARE_AND_VERSION or PROTOCOL_LINK")
+    SNIP = PermissibleValue(
+        text="SNIP",
+        description="Statistics-sensitive Non-linear Iterative Peak-clipping algorithm")
+    TOP_HAT = PermissibleValue(
+        text="TOP_HAT",
+        description="Top-hat morphological filter for baseline estimation")
+
+    _defn = EnumDefinition(
+        name="BaselineCorrectionMethodEnum",
+    )
+
+class NormalizationMethodEnum(EnumDefinitionImpl):
+
+    MEDIAN = PermissibleValue(
+        text="MEDIAN",
+        description="Median spectrum intensity normalization")
+    NONE = PermissibleValue(
+        text="NONE",
+        description="No normalization applied")
+    OTHER = PermissibleValue(
+        text="OTHER",
+        description="Method not listed; specify in PROTOCOL_LINK")
+    REFERENCE_PEAK = PermissibleValue(
+        text="REFERENCE_PEAK",
+        description="Normalization to a single reference m/z peak of known abundance")
+    RMS = PermissibleValue(
+        text="RMS",
+        description="Root Mean Square normalization")
+    TIC = PermissibleValue(
+        text="TIC",
+        description="Total Ion Current normalization - divide each spectrum by its TIC")
+
+    _defn = EnumDefinition(
+        name="NormalizationMethodEnum",
+    )
+
+class SmoothingMethodEnum(EnumDefinitionImpl):
+
+    GAUSSIAN = PermissibleValue(
+        text="GAUSSIAN",
+        description="Gaussian kernel smoothing")
+    NONE = PermissibleValue(
+        text="NONE",
+        description="No spectral smoothing applied")
+    OTHER = PermissibleValue(
+        text="OTHER",
+        description="Method not listed; specify in PROTOCOL_LINK")
+    SAVITZKY_GOLAY = PermissibleValue(
+        text="SAVITZKY_GOLAY",
+        description="Savitzky-Golay polynomial smoothing filter")
+
+    _defn = EnumDefinition(
+        name="SmoothingMethodEnum",
+    )
+
+class SegmentationReferenceModalityEnum(EnumDefinitionImpl):
+
+    H_AND_E = PermissibleValue(
+        text="H_AND_E",
+        description="Segmentation derived from H&E staining and projected onto MSI pixels")
+    IF = PermissibleValue(
+        text="IF",
+        description="Segmentation derived from immunofluorescence")
+    MSI_NATIVE = PermissibleValue(
+        text="MSI_NATIVE",
+        description="Segmentation derived directly from MSI spectral clustering (no external reference)")
+    OTHER = PermissibleValue(
+        text="OTHER",
+        description="Reference modality not listed")
+
+    _defn = EnumDefinition(
+        name="SegmentationReferenceModalityEnum",
+    )
+
+class AdductEnum(EnumDefinitionImpl):
+
+    M_MINUS_H = PermissibleValue(
+        text="M_MINUS_H",
+        description="[M-H]- deprotonated molecule, most common negative mode adduct")
+    M_PLUS_CL = PermissibleValue(
+        text="M_PLUS_CL",
+        description="[M+Cl]- chloride adduct")
+    M_PLUS_H = PermissibleValue(
+        text="M_PLUS_H",
+        description="[M+H]+ protonated molecule, most common positive mode adduct")
+    M_PLUS_K = PermissibleValue(
+        text="M_PLUS_K",
+        description="[M+K]+ potassium adduct")
+    M_PLUS_NA = PermissibleValue(
+        text="M_PLUS_NA",
+        description="[M+Na]+ sodium adduct, common for lipids and carbohydrates")
+    M_PLUS_NH4 = PermissibleValue(
+        text="M_PLUS_NH4",
+        description="[M+NH4]+ ammonium adduct")
+    M_RADICAL_MINUS = PermissibleValue(
+        text="M_RADICAL_MINUS",
+        description="[M]- radical anion")
+    M_RADICAL_PLUS = PermissibleValue(
+        text="M_RADICAL_PLUS",
+        description="[M]+ radical cation (SIMS, some MALDI applications)")
+    NOT_APPLICABLE = PermissibleValue(
+        text="NOT_APPLICABLE",
+        description="No adduct applicable (confidence level 4 unknowns)")
+    OTHER = PermissibleValue(
+        text="OTHER",
+        description="Adduct not listed; specify in MOLECULAR_NAME or annotation protocol")
+
+    _defn = EnumDefinition(
+        name="AdductEnum",
+    )
+
+class DatabaseSourceEnum(EnumDefinitionImpl):
+
+    CHEBI = PermissibleValue(
+        text="CHEBI",
+        description="Chemical Entities of Biological Interest (https://ebi.ac.uk/chebi)")
+    CUSTOM = PermissibleValue(
+        text="CUSTOM",
+        description="In-house or custom reference database; describe in PROTOCOL_LINK")
+    GLYCONNECT = PermissibleValue(
+        text="GLYCONNECT",
+        description="GlyConnect glycan database (https://glyconnect.expasy.org)")
+    GLYTOUCAN = PermissibleValue(
+        text="GLYTOUCAN",
+        description="GlyTouCan glycan repository (https://glytoucan.org)")
+    HMDB = PermissibleValue(
+        text="HMDB",
+        description="Human Metabolome Database (https://hmdb.ca)")
+    LIPID_MAPS = PermissibleValue(
+        text="LIPID_MAPS",
+        description="LIPID MAPS Structure Database (https://lipidmaps.org)")
+    MASSBANK = PermissibleValue(
+        text="MASSBANK",
+        description="MassBank spectral database (https://massbank.eu)")
+    METLIN = PermissibleValue(
+        text="METLIN",
+        description="METLIN metabolite and chemical database (https://metlin.scripps.edu)")
+    NOT_APPLICABLE = PermissibleValue(
+        text="NOT_APPLICABLE",
+        description="No database assignment applicable (confidence level 4 unknowns)")
+    PUBCHEM = PermissibleValue(
+        text="PUBCHEM",
+        description="PubChem compound database (https://pubchem.ncbi.nlm.nih.gov)")
+    UNIPROT = PermissibleValue(
+        text="UNIPROT",
+        description="Universal Protein Resource for protein identifications (https://uniprot.org)")
+
+    _defn = EnumDefinition(
+        name="DatabaseSourceEnum",
+    )
+
+class EvidenceTypeEnum(EnumDefinitionImpl):
+
+    ACCURATE_MASS = PermissibleValue(
+        text="ACCURATE_MASS",
+        description="Annotation supported by accurate mass match within tolerance")
+    DATABASE_SPECTRAL_MATCH = PermissibleValue(
+        text="DATABASE_SPECTRAL_MATCH",
+        description="Matched to a spectral library entry in a public database")
+    ISOTOPE_PATTERN = PermissibleValue(
+        text="ISOTOPE_PATTERN",
+        description="Annotation supported by isotope pattern matching")
+    MSMS_MATCH = PermissibleValue(
+        text="MSMS_MATCH",
+        description="Annotation supported by MS/MS fragmentation spectrum match")
+    REFERENCE_STANDARD = PermissibleValue(
+        text="REFERENCE_STANDARD",
+        description="Confirmed by comparison to an authenticated in-house reference standard")
+    SPATIAL_PATTERN_ONLY = PermissibleValue(
+        text="SPATIAL_PATTERN_ONLY",
+        description="Retained for biological relevance based on spatial distribution; no structural assignment")
+
+    _defn = EnumDefinition(
+        name="EvidenceTypeEnum",
+    )
+
+# Slots
+class slots:
+    pass
+
+slots.caDSR_id = Slot(uri=HTAN.caDSR_id, name="caDSR_id", curie=HTAN.curie('caDSR_id'),
+                   model_uri=HTAN.caDSR_id, domain=None, range=Optional[str])
+
+slots.massSpectrometryImagingData__LEVEL_1_DATA = Slot(uri=HTAN.LEVEL_1_DATA, name="massSpectrometryImagingData__LEVEL_1_DATA", curie=HTAN.curie('LEVEL_1_DATA'),
+                   model_uri=HTAN.massSpectrometryImagingData__LEVEL_1_DATA, domain=None, range=Optional[Union[str, MassSpectrometryImagingLevel1HTANDATAFILEID]])
+
+slots.massSpectrometryImagingData__LEVEL_2_DATA = Slot(uri=HTAN.LEVEL_2_DATA, name="massSpectrometryImagingData__LEVEL_2_DATA", curie=HTAN.curie('LEVEL_2_DATA'),
+                   model_uri=HTAN.massSpectrometryImagingData__LEVEL_2_DATA, domain=None, range=Optional[Union[str, MassSpectrometryImagingLevel2HTANDATAFILEID]])
+
+slots.massSpectrometryImagingData__LEVEL_3_DATA = Slot(uri=HTAN.LEVEL_3_DATA, name="massSpectrometryImagingData__LEVEL_3_DATA", curie=HTAN.curie('LEVEL_3_DATA'),
+                   model_uri=HTAN.massSpectrometryImagingData__LEVEL_3_DATA, domain=None, range=Optional[Union[str, MassSpectrometryImagingLevel3HTANDATAFILEID]])
+
+slots.massSpectrometryImagingData__LEVEL_4_DATA = Slot(uri=HTAN.LEVEL_4_DATA, name="massSpectrometryImagingData__LEVEL_4_DATA", curie=HTAN.curie('LEVEL_4_DATA'),
+                   model_uri=HTAN.massSpectrometryImagingData__LEVEL_4_DATA, domain=None, range=Optional[Union[str, MassSpectrometryImagingLevel4HTANDATAFILEID]])
+
+slots.massSpectrometryImagingData__MOLECULAR_ASSIGNMENTS = Slot(uri=HTAN.MOLECULAR_ASSIGNMENTS, name="massSpectrometryImagingData__MOLECULAR_ASSIGNMENTS", curie=HTAN.curie('MOLECULAR_ASSIGNMENTS'),
+                   model_uri=HTAN.massSpectrometryImagingData__MOLECULAR_ASSIGNMENTS, domain=None, range=Optional[Union[Union[dict, MolecularAssignment], List[Union[dict, MolecularAssignment]]]])
+
+slots.coreFileAttributes__FILENAME = Slot(uri=HTAN.FILENAME, name="coreFileAttributes__FILENAME", curie=HTAN.curie('FILENAME'),
+                   model_uri=HTAN.coreFileAttributes__FILENAME, domain=None, range=str)
+
+slots.coreFileAttributes__FILE_FORMAT = Slot(uri=HTAN.FILE_FORMAT, name="coreFileAttributes__FILE_FORMAT", curie=HTAN.curie('FILE_FORMAT'),
+                   model_uri=HTAN.coreFileAttributes__FILE_FORMAT, domain=None, range=str)
+
+slots.coreFileAttributes__HTAN_DATA_FILE_ID = Slot(uri=HTAN.HTAN_DATA_FILE_ID, name="coreFileAttributes__HTAN_DATA_FILE_ID", curie=HTAN.curie('HTAN_DATA_FILE_ID'),
+                   model_uri=HTAN.coreFileAttributes__HTAN_DATA_FILE_ID, domain=None, range=URIRef,
+                   pattern=re.compile(r'^(?=.{1,50}$)(HTA2[0-2][0-9])_(0000|EXT[0-9]{1,18}|[0-9]{1,21})_(D[0-9]{1,20})$'))
+
+slots.coreFileAttributes__HTAN_PARENT_ID = Slot(uri=HTAN.HTAN_PARENT_ID, name="coreFileAttributes__HTAN_PARENT_ID", curie=HTAN.curie('HTAN_PARENT_ID'),
+                   model_uri=HTAN.coreFileAttributes__HTAN_PARENT_ID, domain=None, range=Union[str, List[str]],
+                   pattern=re.compile(r'^(?=.{1,50}$)(HTA2[0-2][0-9])_(0000|EXT[0-9]{1,18}|[0-9]{1,21})_([BD][0-9]{1,20})$'))
+
+slots.massSpectrometryImagingLevel1__FILE_FORMAT = Slot(uri=HTAN.FILE_FORMAT, name="massSpectrometryImagingLevel1__FILE_FORMAT", curie=HTAN.curie('FILE_FORMAT'),
+                   model_uri=HTAN.massSpectrometryImagingLevel1__FILE_FORMAT, domain=None, range=str,
+                   pattern=re.compile(r'^imzML$'))
+
+slots.massSpectrometryImagingLevel1__FILENAME = Slot(uri=HTAN.FILENAME, name="massSpectrometryImagingLevel1__FILENAME", curie=HTAN.curie('FILENAME'),
+                   model_uri=HTAN.massSpectrometryImagingLevel1__FILENAME, domain=None, range=str,
+                   pattern=re.compile(r'^.+\.imzML$'))
+
+slots.massSpectrometryImagingLevel1__MS_IONIZATION_TECHNIQUE = Slot(uri=HTAN.MS_IONIZATION_TECHNIQUE, name="massSpectrometryImagingLevel1__MS_IONIZATION_TECHNIQUE", curie=HTAN.curie('MS_IONIZATION_TECHNIQUE'),
+                   model_uri=HTAN.massSpectrometryImagingLevel1__MS_IONIZATION_TECHNIQUE, domain=None, range=Union[str, "MsIonizationTechniqueEnum"])
+
+slots.massSpectrometryImagingLevel1__MASS_ANALYZER_TYPE = Slot(uri=HTAN.MASS_ANALYZER_TYPE, name="massSpectrometryImagingLevel1__MASS_ANALYZER_TYPE", curie=HTAN.curie('MASS_ANALYZER_TYPE'),
+                   model_uri=HTAN.massSpectrometryImagingLevel1__MASS_ANALYZER_TYPE, domain=None, range=Union[str, "MassAnalyzerTypeEnum"])
+
+slots.massSpectrometryImagingLevel1__MASS_ANALYSIS_POLARITY = Slot(uri=HTAN.MASS_ANALYSIS_POLARITY, name="massSpectrometryImagingLevel1__MASS_ANALYSIS_POLARITY", curie=HTAN.curie('MASS_ANALYSIS_POLARITY'),
+                   model_uri=HTAN.massSpectrometryImagingLevel1__MASS_ANALYSIS_POLARITY, domain=None, range=Union[str, "MassAnalysisPolarityEnum"])
+
+slots.massSpectrometryImagingLevel1__ANALYTE_CLASS = Slot(uri=HTAN.ANALYTE_CLASS, name="massSpectrometryImagingLevel1__ANALYTE_CLASS", curie=HTAN.curie('ANALYTE_CLASS'),
+                   model_uri=HTAN.massSpectrometryImagingLevel1__ANALYTE_CLASS, domain=None, range=Union[Union[str, "AnalyteClassEnum"], List[Union[str, "AnalyteClassEnum"]]])
+
+slots.massSpectrometryImagingLevel1__IS_TARGETED = Slot(uri=HTAN.IS_TARGETED, name="massSpectrometryImagingLevel1__IS_TARGETED", curie=HTAN.curie('IS_TARGETED'),
+                   model_uri=HTAN.massSpectrometryImagingLevel1__IS_TARGETED, domain=None, range=Union[bool, Bool])
+
+slots.massSpectrometryImagingLevel1__ACQUISITION_INSTRUMENT_VENDOR = Slot(uri=HTAN.ACQUISITION_INSTRUMENT_VENDOR, name="massSpectrometryImagingLevel1__ACQUISITION_INSTRUMENT_VENDOR", curie=HTAN.curie('ACQUISITION_INSTRUMENT_VENDOR'),
+                   model_uri=HTAN.massSpectrometryImagingLevel1__ACQUISITION_INSTRUMENT_VENDOR, domain=None, range=str)
+
+slots.massSpectrometryImagingLevel1__ACQUISITION_INSTRUMENT_MODEL = Slot(uri=HTAN.ACQUISITION_INSTRUMENT_MODEL, name="massSpectrometryImagingLevel1__ACQUISITION_INSTRUMENT_MODEL", curie=HTAN.curie('ACQUISITION_INSTRUMENT_MODEL'),
+                   model_uri=HTAN.massSpectrometryImagingLevel1__ACQUISITION_INSTRUMENT_MODEL, domain=None, range=str)
+
+slots.massSpectrometryImagingLevel1__PIXEL_SIZE_X_UM = Slot(uri=HTAN.PIXEL_SIZE_X_UM, name="massSpectrometryImagingLevel1__PIXEL_SIZE_X_UM", curie=HTAN.curie('PIXEL_SIZE_X_UM'),
+                   model_uri=HTAN.massSpectrometryImagingLevel1__PIXEL_SIZE_X_UM, domain=None, range=float)
+
+slots.massSpectrometryImagingLevel1__PIXEL_SIZE_Y_UM = Slot(uri=HTAN.PIXEL_SIZE_Y_UM, name="massSpectrometryImagingLevel1__PIXEL_SIZE_Y_UM", curie=HTAN.curie('PIXEL_SIZE_Y_UM'),
+                   model_uri=HTAN.massSpectrometryImagingLevel1__PIXEL_SIZE_Y_UM, domain=None, range=float)
+
+slots.massSpectrometryImagingLevel1__MASS_TO_CHARGE_RANGE_LOW_VALUE = Slot(uri=HTAN.MASS_TO_CHARGE_RANGE_LOW_VALUE, name="massSpectrometryImagingLevel1__MASS_TO_CHARGE_RANGE_LOW_VALUE", curie=HTAN.curie('MASS_TO_CHARGE_RANGE_LOW_VALUE'),
+                   model_uri=HTAN.massSpectrometryImagingLevel1__MASS_TO_CHARGE_RANGE_LOW_VALUE, domain=None, range=float)
+
+slots.massSpectrometryImagingLevel1__MASS_TO_CHARGE_RANGE_HIGH_VALUE = Slot(uri=HTAN.MASS_TO_CHARGE_RANGE_HIGH_VALUE, name="massSpectrometryImagingLevel1__MASS_TO_CHARGE_RANGE_HIGH_VALUE", curie=HTAN.curie('MASS_TO_CHARGE_RANGE_HIGH_VALUE'),
+                   model_uri=HTAN.massSpectrometryImagingLevel1__MASS_TO_CHARGE_RANGE_HIGH_VALUE, domain=None, range=float)
+
+slots.massSpectrometryImagingLevel1__ION_MOBILITY = Slot(uri=HTAN.ION_MOBILITY, name="massSpectrometryImagingLevel1__ION_MOBILITY", curie=HTAN.curie('ION_MOBILITY'),
+                   model_uri=HTAN.massSpectrometryImagingLevel1__ION_MOBILITY, domain=None, range=Union[bool, Bool])
+
+slots.massSpectrometryImagingLevel1__SPECTRUM_TYPE = Slot(uri=HTAN.SPECTRUM_TYPE, name="massSpectrometryImagingLevel1__SPECTRUM_TYPE", curie=HTAN.curie('SPECTRUM_TYPE'),
+                   model_uri=HTAN.massSpectrometryImagingLevel1__SPECTRUM_TYPE, domain=None, range=Union[str, "SpectrumTypeEnum"])
+
+slots.massSpectrometryImagingLevel1__MASS_RESOLVING_POWER = Slot(uri=HTAN.MASS_RESOLVING_POWER, name="massSpectrometryImagingLevel1__MASS_RESOLVING_POWER", curie=HTAN.curie('MASS_RESOLVING_POWER'),
+                   model_uri=HTAN.massSpectrometryImagingLevel1__MASS_RESOLVING_POWER, domain=None, range=int)
+
+slots.massSpectrometryImagingLevel1__MASS_TO_CHARGE_RESOLVING_POWER = Slot(uri=HTAN.MASS_TO_CHARGE_RESOLVING_POWER, name="massSpectrometryImagingLevel1__MASS_TO_CHARGE_RESOLVING_POWER", curie=HTAN.curie('MASS_TO_CHARGE_RESOLVING_POWER'),
+                   model_uri=HTAN.massSpectrometryImagingLevel1__MASS_TO_CHARGE_RESOLVING_POWER, domain=None, range=Optional[float])
+
+slots.massSpectrometryImagingLevel1__MS_SCAN_MODE = Slot(uri=HTAN.MS_SCAN_MODE, name="massSpectrometryImagingLevel1__MS_SCAN_MODE", curie=HTAN.curie('MS_SCAN_MODE'),
+                   model_uri=HTAN.massSpectrometryImagingLevel1__MS_SCAN_MODE, domain=None, range=Union[str, "MsScanModeEnum"])
+
+slots.massSpectrometryImagingLevel1__CALIBRATION_TYPE = Slot(uri=HTAN.CALIBRATION_TYPE, name="massSpectrometryImagingLevel1__CALIBRATION_TYPE", curie=HTAN.curie('CALIBRATION_TYPE'),
+                   model_uri=HTAN.massSpectrometryImagingLevel1__CALIBRATION_TYPE, domain=None, range=Union[str, "CalibrationTypeEnum"])
+
+slots.massSpectrometryImagingLevel1__CALIBRANT_MASSES = Slot(uri=HTAN.CALIBRANT_MASSES, name="massSpectrometryImagingLevel1__CALIBRANT_MASSES", curie=HTAN.curie('CALIBRANT_MASSES'),
+                   model_uri=HTAN.massSpectrometryImagingLevel1__CALIBRANT_MASSES, domain=None, range=str)
+
+slots.massSpectrometryImagingLevel1__TIME_SINCE_ACQUISITION_INSTRUMENT_CALIBRATION_VALUE = Slot(uri=HTAN.TIME_SINCE_ACQUISITION_INSTRUMENT_CALIBRATION_VALUE, name="massSpectrometryImagingLevel1__TIME_SINCE_ACQUISITION_INSTRUMENT_CALIBRATION_VALUE", curie=HTAN.curie('TIME_SINCE_ACQUISITION_INSTRUMENT_CALIBRATION_VALUE'),
+                   model_uri=HTAN.massSpectrometryImagingLevel1__TIME_SINCE_ACQUISITION_INSTRUMENT_CALIBRATION_VALUE, domain=None, range=int)
+
+slots.massSpectrometryImagingLevel1__TIME_SINCE_ACQUISITION_INSTRUMENT_CALIBRATION_UNIT = Slot(uri=HTAN.TIME_SINCE_ACQUISITION_INSTRUMENT_CALIBRATION_UNIT, name="massSpectrometryImagingLevel1__TIME_SINCE_ACQUISITION_INSTRUMENT_CALIBRATION_UNIT", curie=HTAN.curie('TIME_SINCE_ACQUISITION_INSTRUMENT_CALIBRATION_UNIT'),
+                   model_uri=HTAN.massSpectrometryImagingLevel1__TIME_SINCE_ACQUISITION_INSTRUMENT_CALIBRATION_UNIT, domain=None, range=Union[str, "TimeUnitEnum"])
+
+slots.massSpectrometryImagingLevel1__SOFTWARE_AND_VERSION = Slot(uri=HTAN.SOFTWARE_AND_VERSION, name="massSpectrometryImagingLevel1__SOFTWARE_AND_VERSION", curie=HTAN.curie('SOFTWARE_AND_VERSION'),
+                   model_uri=HTAN.massSpectrometryImagingLevel1__SOFTWARE_AND_VERSION, domain=None, range=str)
+
+slots.massSpectrometryImagingLevel1__PROTOCOL_LINK = Slot(uri=HTAN.PROTOCOL_LINK, name="massSpectrometryImagingLevel1__PROTOCOL_LINK", curie=HTAN.curie('PROTOCOL_LINK'),
+                   model_uri=HTAN.massSpectrometryImagingLevel1__PROTOCOL_LINK, domain=None, range=Optional[str])
+
+slots.massSpectrometryImagingLevel1__IBD_FILE_UUID = Slot(uri=HTAN.IBD_FILE_UUID, name="massSpectrometryImagingLevel1__IBD_FILE_UUID", curie=HTAN.curie('IBD_FILE_UUID'),
+                   model_uri=HTAN.massSpectrometryImagingLevel1__IBD_FILE_UUID, domain=None, range=str)
+
+slots.massSpectrometryImagingLevel1__PREPARATION_MATRIX = Slot(uri=HTAN.PREPARATION_MATRIX, name="massSpectrometryImagingLevel1__PREPARATION_MATRIX", curie=HTAN.curie('PREPARATION_MATRIX'),
+                   model_uri=HTAN.massSpectrometryImagingLevel1__PREPARATION_MATRIX, domain=None, range=Optional[Union[str, "PreparationMatrixEnum"]])
+
+slots.massSpectrometryImagingLevel1__MATRIX_DEPOSITION_METHOD = Slot(uri=HTAN.MATRIX_DEPOSITION_METHOD, name="massSpectrometryImagingLevel1__MATRIX_DEPOSITION_METHOD", curie=HTAN.curie('MATRIX_DEPOSITION_METHOD'),
+                   model_uri=HTAN.massSpectrometryImagingLevel1__MATRIX_DEPOSITION_METHOD, domain=None, range=Optional[Union[str, "MatrixDepositionMethodEnum"]])
+
+slots.massSpectrometryImagingLevel1__PREPARATION_INSTRUMENT_VENDOR = Slot(uri=HTAN.PREPARATION_INSTRUMENT_VENDOR, name="massSpectrometryImagingLevel1__PREPARATION_INSTRUMENT_VENDOR", curie=HTAN.curie('PREPARATION_INSTRUMENT_VENDOR'),
+                   model_uri=HTAN.massSpectrometryImagingLevel1__PREPARATION_INSTRUMENT_VENDOR, domain=None, range=Optional[str])
+
+slots.massSpectrometryImagingLevel1__PREPARATION_INSTRUMENT_MODEL = Slot(uri=HTAN.PREPARATION_INSTRUMENT_MODEL, name="massSpectrometryImagingLevel1__PREPARATION_INSTRUMENT_MODEL", curie=HTAN.curie('PREPARATION_INSTRUMENT_MODEL'),
+                   model_uri=HTAN.massSpectrometryImagingLevel1__PREPARATION_INSTRUMENT_MODEL, domain=None, range=Optional[str])
+
+slots.massSpectrometryImagingLevel1__ANALYTE_ACQUISITION_ORDER = Slot(uri=HTAN.ANALYTE_ACQUISITION_ORDER, name="massSpectrometryImagingLevel1__ANALYTE_ACQUISITION_ORDER", curie=HTAN.curie('ANALYTE_ACQUISITION_ORDER'),
+                   model_uri=HTAN.massSpectrometryImagingLevel1__ANALYTE_ACQUISITION_ORDER, domain=None, range=Optional[int])
+
+slots.massSpectrometryImagingLevel1__PRE_ACQUISITION_TREATMENT = Slot(uri=HTAN.PRE_ACQUISITION_TREATMENT, name="massSpectrometryImagingLevel1__PRE_ACQUISITION_TREATMENT", curie=HTAN.curie('PRE_ACQUISITION_TREATMENT'),
+                   model_uri=HTAN.massSpectrometryImagingLevel1__PRE_ACQUISITION_TREATMENT, domain=None, range=Optional[Union[str, "PreAcquisitionTreatmentEnum"]])
+
+slots.massSpectrometryImagingLevel1__PASSED_QC = Slot(uri=HTAN.PASSED_QC, name="massSpectrometryImagingLevel1__PASSED_QC", curie=HTAN.curie('PASSED_QC'),
+                   model_uri=HTAN.massSpectrometryImagingLevel1__PASSED_QC, domain=None, range=Union[bool, Bool])
+
+slots.massSpectrometryImagingLevel1__QC_COMMENT = Slot(uri=HTAN.QC_COMMENT, name="massSpectrometryImagingLevel1__QC_COMMENT", curie=HTAN.curie('QC_COMMENT'),
+                   model_uri=HTAN.massSpectrometryImagingLevel1__QC_COMMENT, domain=None, range=Optional[str])
+
+slots.massSpectrometryImagingLevel2__FILE_FORMAT = Slot(uri=HTAN.FILE_FORMAT, name="massSpectrometryImagingLevel2__FILE_FORMAT", curie=HTAN.curie('FILE_FORMAT'),
+                   model_uri=HTAN.massSpectrometryImagingLevel2__FILE_FORMAT, domain=None, range=str,
+                   pattern=re.compile(r'^imzML$'))
+
+slots.massSpectrometryImagingLevel2__FILENAME = Slot(uri=HTAN.FILENAME, name="massSpectrometryImagingLevel2__FILENAME", curie=HTAN.curie('FILENAME'),
+                   model_uri=HTAN.massSpectrometryImagingLevel2__FILENAME, domain=None, range=str,
+                   pattern=re.compile(r'^.+\.imzML$'))
+
+slots.massSpectrometryImagingLevel2__SOFTWARE_AND_VERSION = Slot(uri=HTAN.SOFTWARE_AND_VERSION, name="massSpectrometryImagingLevel2__SOFTWARE_AND_VERSION", curie=HTAN.curie('SOFTWARE_AND_VERSION'),
+                   model_uri=HTAN.massSpectrometryImagingLevel2__SOFTWARE_AND_VERSION, domain=None, range=str)
+
+slots.massSpectrometryImagingLevel2__BASELINE_CORRECTION_METHOD = Slot(uri=HTAN.BASELINE_CORRECTION_METHOD, name="massSpectrometryImagingLevel2__BASELINE_CORRECTION_METHOD", curie=HTAN.curie('BASELINE_CORRECTION_METHOD'),
+                   model_uri=HTAN.massSpectrometryImagingLevel2__BASELINE_CORRECTION_METHOD, domain=None, range=Union[str, "BaselineCorrectionMethodEnum"])
+
+slots.massSpectrometryImagingLevel2__PEAK_PICKING_METHOD = Slot(uri=HTAN.PEAK_PICKING_METHOD, name="massSpectrometryImagingLevel2__PEAK_PICKING_METHOD", curie=HTAN.curie('PEAK_PICKING_METHOD'),
+                   model_uri=HTAN.massSpectrometryImagingLevel2__PEAK_PICKING_METHOD, domain=None, range=str)
+
+slots.massSpectrometryImagingLevel2__PEAK_PICKING_SNR_THRESHOLD = Slot(uri=HTAN.PEAK_PICKING_SNR_THRESHOLD, name="massSpectrometryImagingLevel2__PEAK_PICKING_SNR_THRESHOLD", curie=HTAN.curie('PEAK_PICKING_SNR_THRESHOLD'),
+                   model_uri=HTAN.massSpectrometryImagingLevel2__PEAK_PICKING_SNR_THRESHOLD, domain=None, range=float)
+
+slots.massSpectrometryImagingLevel2__NORMALIZATION_METHOD = Slot(uri=HTAN.NORMALIZATION_METHOD, name="massSpectrometryImagingLevel2__NORMALIZATION_METHOD", curie=HTAN.curie('NORMALIZATION_METHOD'),
+                   model_uri=HTAN.massSpectrometryImagingLevel2__NORMALIZATION_METHOD, domain=None, range=Union[str, "NormalizationMethodEnum"])
+
+slots.massSpectrometryImagingLevel2__MASS_ALIGNMENT_METHOD = Slot(uri=HTAN.MASS_ALIGNMENT_METHOD, name="massSpectrometryImagingLevel2__MASS_ALIGNMENT_METHOD", curie=HTAN.curie('MASS_ALIGNMENT_METHOD'),
+                   model_uri=HTAN.massSpectrometryImagingLevel2__MASS_ALIGNMENT_METHOD, domain=None, range=str)
+
+slots.massSpectrometryImagingLevel2__MASS_TOLERANCE_PPM = Slot(uri=HTAN.MASS_TOLERANCE_PPM, name="massSpectrometryImagingLevel2__MASS_TOLERANCE_PPM", curie=HTAN.curie('MASS_TOLERANCE_PPM'),
+                   model_uri=HTAN.massSpectrometryImagingLevel2__MASS_TOLERANCE_PPM, domain=None, range=float)
+
+slots.massSpectrometryImagingLevel2__SMOOTHING_METHOD = Slot(uri=HTAN.SMOOTHING_METHOD, name="massSpectrometryImagingLevel2__SMOOTHING_METHOD", curie=HTAN.curie('SMOOTHING_METHOD'),
+                   model_uri=HTAN.massSpectrometryImagingLevel2__SMOOTHING_METHOD, domain=None, range=Optional[Union[str, "SmoothingMethodEnum"]])
+
+slots.massSpectrometryImagingLevel2__PROTOCOL_LINK = Slot(uri=HTAN.PROTOCOL_LINK, name="massSpectrometryImagingLevel2__PROTOCOL_LINK", curie=HTAN.curie('PROTOCOL_LINK'),
+                   model_uri=HTAN.massSpectrometryImagingLevel2__PROTOCOL_LINK, domain=None, range=Optional[str])
+
+slots.massSpectrometryImagingLevel2__MEDIAN_TIC = Slot(uri=HTAN.MEDIAN_TIC, name="massSpectrometryImagingLevel2__MEDIAN_TIC", curie=HTAN.curie('MEDIAN_TIC'),
+                   model_uri=HTAN.massSpectrometryImagingLevel2__MEDIAN_TIC, domain=None, range=float)
+
+slots.massSpectrometryImagingLevel2__TIC_CV = Slot(uri=HTAN.TIC_CV, name="massSpectrometryImagingLevel2__TIC_CV", curie=HTAN.curie('TIC_CV'),
+                   model_uri=HTAN.massSpectrometryImagingLevel2__TIC_CV, domain=None, range=float)
+
+slots.massSpectrometryImagingLevel2__MASS_ACCURACY_PPM = Slot(uri=HTAN.MASS_ACCURACY_PPM, name="massSpectrometryImagingLevel2__MASS_ACCURACY_PPM", curie=HTAN.curie('MASS_ACCURACY_PPM'),
+                   model_uri=HTAN.massSpectrometryImagingLevel2__MASS_ACCURACY_PPM, domain=None, range=float)
+
+slots.massSpectrometryImagingLevel2__PIXEL_COMPLETION_RATE = Slot(uri=HTAN.PIXEL_COMPLETION_RATE, name="massSpectrometryImagingLevel2__PIXEL_COMPLETION_RATE", curie=HTAN.curie('PIXEL_COMPLETION_RATE'),
+                   model_uri=HTAN.massSpectrometryImagingLevel2__PIXEL_COMPLETION_RATE, domain=None, range=float)
+
+slots.massSpectrometryImagingLevel2__NUM_DETECTED_PEAKS = Slot(uri=HTAN.NUM_DETECTED_PEAKS, name="massSpectrometryImagingLevel2__NUM_DETECTED_PEAKS", curie=HTAN.curie('NUM_DETECTED_PEAKS'),
+                   model_uri=HTAN.massSpectrometryImagingLevel2__NUM_DETECTED_PEAKS, domain=None, range=int)
+
+slots.massSpectrometryImagingLevel2__PASSED_QC = Slot(uri=HTAN.PASSED_QC, name="massSpectrometryImagingLevel2__PASSED_QC", curie=HTAN.curie('PASSED_QC'),
+                   model_uri=HTAN.massSpectrometryImagingLevel2__PASSED_QC, domain=None, range=Union[bool, Bool])
+
+slots.massSpectrometryImagingLevel2__QC_COMMENT = Slot(uri=HTAN.QC_COMMENT, name="massSpectrometryImagingLevel2__QC_COMMENT", curie=HTAN.curie('QC_COMMENT'),
+                   model_uri=HTAN.massSpectrometryImagingLevel2__QC_COMMENT, domain=None, range=Optional[str])
+
+slots.massSpectrometryImagingLevel3__FILE_FORMAT = Slot(uri=HTAN.FILE_FORMAT, name="massSpectrometryImagingLevel3__FILE_FORMAT", curie=HTAN.curie('FILE_FORMAT'),
+                   model_uri=HTAN.massSpectrometryImagingLevel3__FILE_FORMAT, domain=None, range=str,
+                   pattern=re.compile(r'^ome\.tiff?$'))
+
+slots.massSpectrometryImagingLevel3__FILENAME = Slot(uri=HTAN.FILENAME, name="massSpectrometryImagingLevel3__FILENAME", curie=HTAN.curie('FILENAME'),
+                   model_uri=HTAN.massSpectrometryImagingLevel3__FILENAME, domain=None, range=str,
+                   pattern=re.compile(r'^.+\.ome\.tiff?$'))
+
+slots.massSpectrometryImagingLevel3__NUM_ANNOTATED_CHANNELS = Slot(uri=HTAN.NUM_ANNOTATED_CHANNELS, name="massSpectrometryImagingLevel3__NUM_ANNOTATED_CHANNELS", curie=HTAN.curie('NUM_ANNOTATED_CHANNELS'),
+                   model_uri=HTAN.massSpectrometryImagingLevel3__NUM_ANNOTATED_CHANNELS, domain=None, range=int)
+
+slots.massSpectrometryImagingLevel3__NUM_UNKNOWN_CHANNELS = Slot(uri=HTAN.NUM_UNKNOWN_CHANNELS, name="massSpectrometryImagingLevel3__NUM_UNKNOWN_CHANNELS", curie=HTAN.curie('NUM_UNKNOWN_CHANNELS'),
+                   model_uri=HTAN.massSpectrometryImagingLevel3__NUM_UNKNOWN_CHANNELS, domain=None, range=int)
+
+slots.massSpectrometryImagingLevel3__SOFTWARE_AND_VERSION = Slot(uri=HTAN.SOFTWARE_AND_VERSION, name="massSpectrometryImagingLevel3__SOFTWARE_AND_VERSION", curie=HTAN.curie('SOFTWARE_AND_VERSION'),
+                   model_uri=HTAN.massSpectrometryImagingLevel3__SOFTWARE_AND_VERSION, domain=None, range=str)
+
+slots.massSpectrometryImagingLevel3__PROTOCOL_LINK = Slot(uri=HTAN.PROTOCOL_LINK, name="massSpectrometryImagingLevel3__PROTOCOL_LINK", curie=HTAN.curie('PROTOCOL_LINK'),
+                   model_uri=HTAN.massSpectrometryImagingLevel3__PROTOCOL_LINK, domain=None, range=Optional[str])
+
+slots.massSpectrometryImagingLevel3__PASSED_QC = Slot(uri=HTAN.PASSED_QC, name="massSpectrometryImagingLevel3__PASSED_QC", curie=HTAN.curie('PASSED_QC'),
+                   model_uri=HTAN.massSpectrometryImagingLevel3__PASSED_QC, domain=None, range=Union[bool, Bool])
+
+slots.massSpectrometryImagingLevel3__QC_COMMENT = Slot(uri=HTAN.QC_COMMENT, name="massSpectrometryImagingLevel3__QC_COMMENT", curie=HTAN.curie('QC_COMMENT'),
+                   model_uri=HTAN.massSpectrometryImagingLevel3__QC_COMMENT, domain=None, range=Optional[str])
+
+slots.massSpectrometryImagingLevel4__FILE_FORMAT = Slot(uri=HTAN.FILE_FORMAT, name="massSpectrometryImagingLevel4__FILE_FORMAT", curie=HTAN.curie('FILE_FORMAT'),
+                   model_uri=HTAN.massSpectrometryImagingLevel4__FILE_FORMAT, domain=None, range=str,
+                   pattern=re.compile(r'^(ome\.tiff?|csv)$'))
+
+slots.massSpectrometryImagingLevel4__FILENAME = Slot(uri=HTAN.FILENAME, name="massSpectrometryImagingLevel4__FILENAME", curie=HTAN.curie('FILENAME'),
+                   model_uri=HTAN.massSpectrometryImagingLevel4__FILENAME, domain=None, range=str,
+                   pattern=re.compile(r'^.+\.(ome\.tiff?|csv)$'))
+
+slots.massSpectrometryImagingLevel4__SEGMENTATION_METHOD = Slot(uri=HTAN.SEGMENTATION_METHOD, name="massSpectrometryImagingLevel4__SEGMENTATION_METHOD", curie=HTAN.curie('SEGMENTATION_METHOD'),
+                   model_uri=HTAN.massSpectrometryImagingLevel4__SEGMENTATION_METHOD, domain=None, range=str)
+
+slots.massSpectrometryImagingLevel4__SEGMENTATION_CLASS_COUNT = Slot(uri=HTAN.SEGMENTATION_CLASS_COUNT, name="massSpectrometryImagingLevel4__SEGMENTATION_CLASS_COUNT", curie=HTAN.curie('SEGMENTATION_CLASS_COUNT'),
+                   model_uri=HTAN.massSpectrometryImagingLevel4__SEGMENTATION_CLASS_COUNT, domain=None, range=int)
+
+slots.massSpectrometryImagingLevel4__SEGMENTATION_REFERENCE_MODALITY = Slot(uri=HTAN.SEGMENTATION_REFERENCE_MODALITY, name="massSpectrometryImagingLevel4__SEGMENTATION_REFERENCE_MODALITY", curie=HTAN.curie('SEGMENTATION_REFERENCE_MODALITY'),
+                   model_uri=HTAN.massSpectrometryImagingLevel4__SEGMENTATION_REFERENCE_MODALITY, domain=None, range=Union[str, "SegmentationReferenceModalityEnum"])
+
+slots.massSpectrometryImagingLevel4__PASSED_QC = Slot(uri=HTAN.PASSED_QC, name="massSpectrometryImagingLevel4__PASSED_QC", curie=HTAN.curie('PASSED_QC'),
+                   model_uri=HTAN.massSpectrometryImagingLevel4__PASSED_QC, domain=None, range=Union[bool, Bool])
+
+slots.massSpectrometryImagingLevel4__QC_COMMENT = Slot(uri=HTAN.QC_COMMENT, name="massSpectrometryImagingLevel4__QC_COMMENT", curie=HTAN.curie('QC_COMMENT'),
+                   model_uri=HTAN.massSpectrometryImagingLevel4__QC_COMMENT, domain=None, range=Optional[str])
+
+slots.molecularAssignment__HTAN_DATA_FILE_ID = Slot(uri=HTAN.HTAN_DATA_FILE_ID, name="molecularAssignment__HTAN_DATA_FILE_ID", curie=HTAN.curie('HTAN_DATA_FILE_ID'),
+                   model_uri=HTAN.molecularAssignment__HTAN_DATA_FILE_ID, domain=None, range=str,
+                   pattern=re.compile(r'^(?=.{1,50}$)(HTA2[0-2][0-9])_(0000|EXT[0-9]{1,18}|[0-9]{1,21})_(D[0-9]{1,20})$'))
+
+slots.molecularAssignment__CHANNEL_INDEX = Slot(uri=HTAN.CHANNEL_INDEX, name="molecularAssignment__CHANNEL_INDEX", curie=HTAN.curie('CHANNEL_INDEX'),
+                   model_uri=HTAN.molecularAssignment__CHANNEL_INDEX, domain=None, range=int)
+
+slots.molecularAssignment__MZ_OBSERVED = Slot(uri=HTAN.MZ_OBSERVED, name="molecularAssignment__MZ_OBSERVED", curie=HTAN.curie('MZ_OBSERVED'),
+                   model_uri=HTAN.molecularAssignment__MZ_OBSERVED, domain=None, range=float)
+
+slots.molecularAssignment__MZ_THEORETICAL = Slot(uri=HTAN.MZ_THEORETICAL, name="molecularAssignment__MZ_THEORETICAL", curie=HTAN.curie('MZ_THEORETICAL'),
+                   model_uri=HTAN.molecularAssignment__MZ_THEORETICAL, domain=None, range=Optional[float])
+
+slots.molecularAssignment__MASS_ERROR_PPM = Slot(uri=HTAN.MASS_ERROR_PPM, name="molecularAssignment__MASS_ERROR_PPM", curie=HTAN.curie('MASS_ERROR_PPM'),
+                   model_uri=HTAN.molecularAssignment__MASS_ERROR_PPM, domain=None, range=Optional[float])
+
+slots.molecularAssignment__MOLECULAR_FORMULA = Slot(uri=HTAN.MOLECULAR_FORMULA, name="molecularAssignment__MOLECULAR_FORMULA", curie=HTAN.curie('MOLECULAR_FORMULA'),
+                   model_uri=HTAN.molecularAssignment__MOLECULAR_FORMULA, domain=None, range=Optional[str])
+
+slots.molecularAssignment__MOLECULAR_NAME = Slot(uri=HTAN.MOLECULAR_NAME, name="molecularAssignment__MOLECULAR_NAME", curie=HTAN.curie('MOLECULAR_NAME'),
+                   model_uri=HTAN.molecularAssignment__MOLECULAR_NAME, domain=None, range=str)
+
+slots.molecularAssignment__ADDUCT = Slot(uri=HTAN.ADDUCT, name="molecularAssignment__ADDUCT", curie=HTAN.curie('ADDUCT'),
+                   model_uri=HTAN.molecularAssignment__ADDUCT, domain=None, range=Optional[Union[str, "AdductEnum"]])
+
+slots.molecularAssignment__DATABASE_SOURCE = Slot(uri=HTAN.DATABASE_SOURCE, name="molecularAssignment__DATABASE_SOURCE", curie=HTAN.curie('DATABASE_SOURCE'),
+                   model_uri=HTAN.molecularAssignment__DATABASE_SOURCE, domain=None, range=Optional[Union[str, "DatabaseSourceEnum"]])
+
+slots.molecularAssignment__DATABASE_ID = Slot(uri=HTAN.DATABASE_ID, name="molecularAssignment__DATABASE_ID", curie=HTAN.curie('DATABASE_ID'),
+                   model_uri=HTAN.molecularAssignment__DATABASE_ID, domain=None, range=Optional[str])
+
+slots.molecularAssignment__DATABASE_VERSION = Slot(uri=HTAN.DATABASE_VERSION, name="molecularAssignment__DATABASE_VERSION", curie=HTAN.curie('DATABASE_VERSION'),
+                   model_uri=HTAN.molecularAssignment__DATABASE_VERSION, domain=None, range=Optional[str])
+
+slots.molecularAssignment__SOFTWARE_AND_VERSION = Slot(uri=HTAN.SOFTWARE_AND_VERSION, name="molecularAssignment__SOFTWARE_AND_VERSION", curie=HTAN.curie('SOFTWARE_AND_VERSION'),
+                   model_uri=HTAN.molecularAssignment__SOFTWARE_AND_VERSION, domain=None, range=str)
+
+slots.molecularAssignment__CONFIDENCE_LEVEL = Slot(uri=HTAN.CONFIDENCE_LEVEL, name="molecularAssignment__CONFIDENCE_LEVEL", curie=HTAN.curie('CONFIDENCE_LEVEL'),
+                   model_uri=HTAN.molecularAssignment__CONFIDENCE_LEVEL, domain=None, range=int)
+
+slots.molecularAssignment__EVIDENCE_TYPE = Slot(uri=HTAN.EVIDENCE_TYPE, name="molecularAssignment__EVIDENCE_TYPE", curie=HTAN.curie('EVIDENCE_TYPE'),
+                   model_uri=HTAN.molecularAssignment__EVIDENCE_TYPE, domain=None, range=Union[Union[str, "EvidenceTypeEnum"], List[Union[str, "EvidenceTypeEnum"]]])

--- a/modules/MassSpectrometryImaging/src/htan_massspectrometryimaging/datamodel/mass_spectrometry_imaging.py
+++ b/modules/MassSpectrometryImaging/src/htan_massspectrometryimaging/datamodel/mass_spectrometry_imaging.py
@@ -1,5 +1,5 @@
 # Auto generated from mass_spectrometry_imaging.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-07-01T14:24:40
+# Generation date: 2026-07-01T14:40:50
 # Schema: MassSpectrometryImaging
 #
 # id: https://w3id.org/htan/mass_spectrometry_imaging
@@ -108,24 +108,24 @@ class MassSpectrometryImagingData(YAMLRoot):
     class_name: ClassVar[str] = "MassSpectrometryImagingData"
     class_model_uri: ClassVar[URIRef] = HTAN.MassSpectrometryImagingData
 
-    LEVEL_1_DATA: Optional[Union[str, MassSpectrometryImagingLevel1HTANDATAFILEID]] = None
-    LEVEL_2_DATA: Optional[Union[str, MassSpectrometryImagingLevel2HTANDATAFILEID]] = None
-    LEVEL_3_DATA: Optional[Union[str, MassSpectrometryImagingLevel3HTANDATAFILEID]] = None
-    LEVEL_4_DATA: Optional[Union[str, MassSpectrometryImagingLevel4HTANDATAFILEID]] = None
+    LEVEL_1_DATA: Optional[Union[dict, "MassSpectrometryImagingLevel1"]] = None
+    LEVEL_2_DATA: Optional[Union[dict, "MassSpectrometryImagingLevel2"]] = None
+    LEVEL_3_DATA: Optional[Union[dict, "MassSpectrometryImagingLevel3"]] = None
+    LEVEL_4_DATA: Optional[Union[dict, "MassSpectrometryImagingLevel4"]] = None
     MOLECULAR_ASSIGNMENTS: Optional[Union[Union[dict, "MolecularAssignment"], List[Union[dict, "MolecularAssignment"]]]] = empty_list()
 
     def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
-        if self.LEVEL_1_DATA is not None and not isinstance(self.LEVEL_1_DATA, MassSpectrometryImagingLevel1HTANDATAFILEID):
-            self.LEVEL_1_DATA = MassSpectrometryImagingLevel1HTANDATAFILEID(self.LEVEL_1_DATA)
+        if self.LEVEL_1_DATA is not None and not isinstance(self.LEVEL_1_DATA, MassSpectrometryImagingLevel1):
+            self.LEVEL_1_DATA = MassSpectrometryImagingLevel1(**as_dict(self.LEVEL_1_DATA))
 
-        if self.LEVEL_2_DATA is not None and not isinstance(self.LEVEL_2_DATA, MassSpectrometryImagingLevel2HTANDATAFILEID):
-            self.LEVEL_2_DATA = MassSpectrometryImagingLevel2HTANDATAFILEID(self.LEVEL_2_DATA)
+        if self.LEVEL_2_DATA is not None and not isinstance(self.LEVEL_2_DATA, MassSpectrometryImagingLevel2):
+            self.LEVEL_2_DATA = MassSpectrometryImagingLevel2(**as_dict(self.LEVEL_2_DATA))
 
-        if self.LEVEL_3_DATA is not None and not isinstance(self.LEVEL_3_DATA, MassSpectrometryImagingLevel3HTANDATAFILEID):
-            self.LEVEL_3_DATA = MassSpectrometryImagingLevel3HTANDATAFILEID(self.LEVEL_3_DATA)
+        if self.LEVEL_3_DATA is not None and not isinstance(self.LEVEL_3_DATA, MassSpectrometryImagingLevel3):
+            self.LEVEL_3_DATA = MassSpectrometryImagingLevel3(**as_dict(self.LEVEL_3_DATA))
 
-        if self.LEVEL_4_DATA is not None and not isinstance(self.LEVEL_4_DATA, MassSpectrometryImagingLevel4HTANDATAFILEID):
-            self.LEVEL_4_DATA = MassSpectrometryImagingLevel4HTANDATAFILEID(self.LEVEL_4_DATA)
+        if self.LEVEL_4_DATA is not None and not isinstance(self.LEVEL_4_DATA, MassSpectrometryImagingLevel4):
+            self.LEVEL_4_DATA = MassSpectrometryImagingLevel4(**as_dict(self.LEVEL_4_DATA))
 
         if not isinstance(self.MOLECULAR_ASSIGNMENTS, list):
             self.MOLECULAR_ASSIGNMENTS = [self.MOLECULAR_ASSIGNMENTS] if self.MOLECULAR_ASSIGNMENTS is not None else []
@@ -1161,20 +1161,17 @@ class EvidenceTypeEnum(EnumDefinitionImpl):
 class slots:
     pass
 
-slots.caDSR_id = Slot(uri=HTAN.caDSR_id, name="caDSR_id", curie=HTAN.curie('caDSR_id'),
-                   model_uri=HTAN.caDSR_id, domain=None, range=Optional[str])
-
 slots.massSpectrometryImagingData__LEVEL_1_DATA = Slot(uri=HTAN.LEVEL_1_DATA, name="massSpectrometryImagingData__LEVEL_1_DATA", curie=HTAN.curie('LEVEL_1_DATA'),
-                   model_uri=HTAN.massSpectrometryImagingData__LEVEL_1_DATA, domain=None, range=Optional[Union[str, MassSpectrometryImagingLevel1HTANDATAFILEID]])
+                   model_uri=HTAN.massSpectrometryImagingData__LEVEL_1_DATA, domain=None, range=Optional[Union[dict, MassSpectrometryImagingLevel1]])
 
 slots.massSpectrometryImagingData__LEVEL_2_DATA = Slot(uri=HTAN.LEVEL_2_DATA, name="massSpectrometryImagingData__LEVEL_2_DATA", curie=HTAN.curie('LEVEL_2_DATA'),
-                   model_uri=HTAN.massSpectrometryImagingData__LEVEL_2_DATA, domain=None, range=Optional[Union[str, MassSpectrometryImagingLevel2HTANDATAFILEID]])
+                   model_uri=HTAN.massSpectrometryImagingData__LEVEL_2_DATA, domain=None, range=Optional[Union[dict, MassSpectrometryImagingLevel2]])
 
 slots.massSpectrometryImagingData__LEVEL_3_DATA = Slot(uri=HTAN.LEVEL_3_DATA, name="massSpectrometryImagingData__LEVEL_3_DATA", curie=HTAN.curie('LEVEL_3_DATA'),
-                   model_uri=HTAN.massSpectrometryImagingData__LEVEL_3_DATA, domain=None, range=Optional[Union[str, MassSpectrometryImagingLevel3HTANDATAFILEID]])
+                   model_uri=HTAN.massSpectrometryImagingData__LEVEL_3_DATA, domain=None, range=Optional[Union[dict, MassSpectrometryImagingLevel3]])
 
 slots.massSpectrometryImagingData__LEVEL_4_DATA = Slot(uri=HTAN.LEVEL_4_DATA, name="massSpectrometryImagingData__LEVEL_4_DATA", curie=HTAN.curie('LEVEL_4_DATA'),
-                   model_uri=HTAN.massSpectrometryImagingData__LEVEL_4_DATA, domain=None, range=Optional[Union[str, MassSpectrometryImagingLevel4HTANDATAFILEID]])
+                   model_uri=HTAN.massSpectrometryImagingData__LEVEL_4_DATA, domain=None, range=Optional[Union[dict, MassSpectrometryImagingLevel4]])
 
 slots.massSpectrometryImagingData__MOLECULAR_ASSIGNMENTS = Slot(uri=HTAN.MOLECULAR_ASSIGNMENTS, name="massSpectrometryImagingData__MOLECULAR_ASSIGNMENTS", curie=HTAN.curie('MOLECULAR_ASSIGNMENTS'),
                    model_uri=HTAN.massSpectrometryImagingData__MOLECULAR_ASSIGNMENTS, domain=None, range=Optional[Union[Union[dict, MolecularAssignment], List[Union[dict, MolecularAssignment]]]])
@@ -1253,7 +1250,8 @@ slots.massSpectrometryImagingLevel1__CALIBRATION_TYPE = Slot(uri=HTAN.CALIBRATIO
                    model_uri=HTAN.massSpectrometryImagingLevel1__CALIBRATION_TYPE, domain=None, range=Union[str, "CalibrationTypeEnum"])
 
 slots.massSpectrometryImagingLevel1__CALIBRANT_MASSES = Slot(uri=HTAN.CALIBRANT_MASSES, name="massSpectrometryImagingLevel1__CALIBRANT_MASSES", curie=HTAN.curie('CALIBRANT_MASSES'),
-                   model_uri=HTAN.massSpectrometryImagingLevel1__CALIBRANT_MASSES, domain=None, range=str)
+                   model_uri=HTAN.massSpectrometryImagingLevel1__CALIBRANT_MASSES, domain=None, range=str,
+                   pattern=re.compile(r'^[0-9]+(\.[0-9]+)?(, ?[0-9]+(\.[0-9]+)?)*$'))
 
 slots.massSpectrometryImagingLevel1__TIME_SINCE_ACQUISITION_INSTRUMENT_CALIBRATION_VALUE = Slot(uri=HTAN.TIME_SINCE_ACQUISITION_INSTRUMENT_CALIBRATION_VALUE, name="massSpectrometryImagingLevel1__TIME_SINCE_ACQUISITION_INSTRUMENT_CALIBRATION_VALUE", curie=HTAN.curie('TIME_SINCE_ACQUISITION_INSTRUMENT_CALIBRATION_VALUE'),
                    model_uri=HTAN.massSpectrometryImagingLevel1__TIME_SINCE_ACQUISITION_INSTRUMENT_CALIBRATION_VALUE, domain=None, range=int)

--- a/modules/MassSpectrometryImaging/tests/test_mass_spectrometry_imaging.py
+++ b/modules/MassSpectrometryImaging/tests/test_mass_spectrometry_imaging.py
@@ -1,0 +1,184 @@
+"""Tests for the HTAN Mass Spectrometry Imaging (MSI) module."""
+
+import re
+
+import pytest
+from linkml_runtime.utils.schemaview import SchemaView
+
+SCHEMA = "modules/MassSpectrometryImaging/domains/mass_spectrometry_imaging.yaml"
+
+LEVEL_CLASSES = [
+    "MassSpectrometryImagingLevel1",
+    "MassSpectrometryImagingLevel2",
+    "MassSpectrometryImagingLevel3",
+    "MassSpectrometryImagingLevel4",
+]
+
+
+@pytest.fixture(scope="module")
+def sv():
+    return SchemaView(SCHEMA)
+
+
+class TestSchema:
+    def test_schema_loads(self, sv):
+        assert sv is not None
+
+    def test_container_class(self, sv):
+        assert "MassSpectrometryImagingData" in sv.all_classes()
+        container = sv.get_class("MassSpectrometryImagingData")
+        slots = sv.class_slots("MassSpectrometryImagingData")
+        for s in ["LEVEL_1_DATA", "LEVEL_2_DATA", "LEVEL_3_DATA", "LEVEL_4_DATA", "MOLECULAR_ASSIGNMENTS"]:
+            assert s in slots, f"{s} missing from container"
+
+    def test_molecular_assignments_inlined_as_list(self, sv):
+        slot = sv.induced_slot("MOLECULAR_ASSIGNMENTS", "MassSpectrometryImagingData")
+        assert slot.range == "MolecularAssignment"
+        assert slot.multivalued is True
+        assert slot.inlined_as_list is True
+
+
+class TestInheritance:
+    @pytest.mark.parametrize("cls", LEVEL_CLASSES)
+    def test_levels_inherit_core(self, sv, cls):
+        assert cls in sv.all_classes()
+        assert sv.get_class(cls).is_a == "CoreFileAttributes"
+
+    def test_molecular_assignment_is_standalone(self, sv):
+        """The RecordSet row class must NOT inherit CoreFileAttributes (like ChannelMetadata)."""
+        ma = sv.get_class("MolecularAssignment")
+        assert ma is not None
+        assert ma.is_a is None
+
+    def test_levels_inherit_core_identifiers(self, sv):
+        for cls in LEVEL_CLASSES:
+            slots = sv.class_slots(cls)
+            for s in ["HTAN_DATA_FILE_ID", "HTAN_PARENT_ID", "FILENAME", "FILE_FORMAT"]:
+                assert s in slots, f"{s} not inherited by {cls}"
+
+
+class TestLevel1:
+    def test_required_slots(self, sv):
+        cls = "MassSpectrometryImagingLevel1"
+        required = [
+            "MS_IONIZATION_TECHNIQUE", "MASS_ANALYZER_TYPE", "MASS_ANALYSIS_POLARITY",
+            "ANALYTE_CLASS", "IS_TARGETED", "ACQUISITION_INSTRUMENT_VENDOR",
+            "ACQUISITION_INSTRUMENT_MODEL", "PIXEL_SIZE_X_UM", "PIXEL_SIZE_Y_UM",
+            "MASS_TO_CHARGE_RANGE_LOW_VALUE", "MASS_TO_CHARGE_RANGE_HIGH_VALUE",
+            "ION_MOBILITY", "SPECTRUM_TYPE", "MASS_RESOLVING_POWER", "MS_SCAN_MODE",
+            "CALIBRATION_TYPE", "CALIBRANT_MASSES", "SOFTWARE_AND_VERSION",
+            "IBD_FILE_UUID", "PASSED_QC",
+        ]
+        for s in required:
+            slot = sv.induced_slot(s, cls)
+            assert slot.required is True, f"{s} should be required at Level 1"
+
+    def test_optional_slots(self, sv):
+        cls = "MassSpectrometryImagingLevel1"
+        optional = [
+            "MASS_TO_CHARGE_RESOLVING_POWER", "PROTOCOL_LINK",
+            "PREPARATION_MATRIX", "MATRIX_DEPOSITION_METHOD",
+            "PREPARATION_INSTRUMENT_VENDOR", "PREPARATION_INSTRUMENT_MODEL",
+            "ANALYTE_ACQUISITION_ORDER", "PRE_ACQUISITION_TREATMENT", "QC_COMMENT",
+        ]
+        for s in optional:
+            slot = sv.induced_slot(s, cls)
+            assert not slot.required, f"{s} should be optional at Level 1"
+
+    def test_analyte_class_multivalued(self, sv):
+        slot = sv.induced_slot("ANALYTE_CLASS", "MassSpectrometryImagingLevel1")
+        assert slot.multivalued is True
+
+    def test_every_attribute_has_title_and_description(self, sv):
+        cls = sv.get_class("MassSpectrometryImagingLevel1")
+        for name, attr in cls.attributes.items():
+            assert attr.title, f"{name} missing title"
+            assert attr.description, f"{name} missing description"
+
+    def test_maldi_conditional_rule_present(self, sv):
+        cls = sv.get_class("MassSpectrometryImagingLevel1")
+        rule_text = " ".join(r.description or "" for r in (cls.rules or []))
+        assert "MALDI" in rule_text
+        # the rule makes PREPARATION_MATRIX / MATRIX_DEPOSITION_METHOD required on MALDI
+        post_slots = set()
+        for r in cls.rules or []:
+            if r.postconditions and r.postconditions.slot_conditions:
+                post_slots.update(r.postconditions.slot_conditions.keys())
+        assert "PREPARATION_MATRIX" in post_slots
+        assert "MATRIX_DEPOSITION_METHOD" in post_slots
+
+
+class TestEnums:
+    def test_enums_present(self, sv):
+        expected = [
+            "MsIonizationTechniqueEnum", "MassAnalyzerTypeEnum", "MassAnalysisPolarityEnum",
+            "AnalyteClassEnum", "SpectrumTypeEnum", "MsScanModeEnum", "CalibrationTypeEnum",
+            "TimeUnitEnum", "PreparationMatrixEnum", "MatrixDepositionMethodEnum",
+            "PreAcquisitionTreatmentEnum", "BaselineCorrectionMethodEnum",
+            "NormalizationMethodEnum", "SmoothingMethodEnum", "SegmentationReferenceModalityEnum",
+            "AdductEnum", "DatabaseSourceEnum", "EvidenceTypeEnum",
+        ]
+        all_enums = sv.all_enums()
+        for e in expected:
+            assert e in all_enums, f"{e} missing"
+
+    def test_multi_class_removed(self, sv):
+        pv = sv.get_enum("AnalyteClassEnum").permissible_values
+        assert "MULTI_CLASS" not in pv
+        assert "LIPIDS" in pv and "GLYCANS" in pv
+
+    def test_enums_alphabetical(self, sv):
+        """CLAUDE.md rule: permissible values are alphabetically ordered."""
+        for ename, enum in sv.all_enums().items():
+            values = list(enum.permissible_values.keys())
+            assert values == sorted(values), f"{ename} values not alphabetical: {values}"
+
+    def test_permissible_values_have_descriptions(self, sv):
+        for ename, enum in sv.all_enums().items():
+            for vname, v in enum.permissible_values.items():
+                assert v.description, f"{ename}.{vname} missing description"
+
+
+class TestMolecularAssignments:
+    def test_required_columns(self, sv):
+        cls = "MolecularAssignment"
+        required = ["HTAN_DATA_FILE_ID", "CHANNEL_INDEX", "MZ_OBSERVED", "MOLECULAR_NAME",
+                    "SOFTWARE_AND_VERSION", "CONFIDENCE_LEVEL", "EVIDENCE_TYPE"]
+        for s in required:
+            assert sv.induced_slot(s, cls).required is True, f"{s} should be required"
+
+    def test_conditional_columns_optional_by_default(self, sv):
+        cls = "MolecularAssignment"
+        conditional = ["MZ_THEORETICAL", "MASS_ERROR_PPM", "MOLECULAR_FORMULA",
+                       "ADDUCT", "DATABASE_SOURCE", "DATABASE_ID", "DATABASE_VERSION"]
+        for s in conditional:
+            assert not sv.induced_slot(s, cls).required, f"{s} should be optional (rule-gated)"
+
+    def test_evidence_type_multivalued(self, sv):
+        slot = sv.induced_slot("EVIDENCE_TYPE", "MolecularAssignment")
+        assert slot.multivalued is True
+
+    def test_confidence_level_bounds(self, sv):
+        slot = sv.induced_slot("CONFIDENCE_LEVEL", "MolecularAssignment")
+        assert slot.minimum_value == 1
+        assert slot.maximum_value == 4
+
+    def test_conditional_rules_present(self, sv):
+        cls = sv.get_class("MolecularAssignment")
+        assert cls.rules, "MolecularAssignment should define conditional rules"
+        gated = set()
+        for r in cls.rules:
+            if r.postconditions and r.postconditions.slot_conditions:
+                gated.update(r.postconditions.slot_conditions.keys())
+        for s in ["MZ_THEORETICAL", "ADDUCT", "DATABASE_SOURCE", "MOLECULAR_FORMULA",
+                  "MASS_ERROR_PPM", "DATABASE_ID", "DATABASE_VERSION"]:
+            assert s in gated, f"{s} not covered by any rule postcondition"
+
+
+class TestPatterns:
+    def test_data_file_id_pattern_in_recordset(self, sv):
+        slot = sv.induced_slot("HTAN_DATA_FILE_ID", "MolecularAssignment")
+        assert slot.pattern
+        rx = re.compile(slot.pattern)
+        assert rx.match("HTA200_1234_D003")
+        assert not rx.match("HTA200_1234_B002")  # biospecimen id should not match

--- a/modules/MassSpectrometryImaging/tests/test_mass_spectrometry_imaging.py
+++ b/modules/MassSpectrometryImaging/tests/test_mass_spectrometry_imaging.py
@@ -21,12 +21,13 @@ def sv():
 
 
 class TestSchema:
+    """Schema loading and container wiring."""
+
     def test_schema_loads(self, sv):
         assert sv is not None
 
     def test_container_class(self, sv):
         assert "MassSpectrometryImagingData" in sv.all_classes()
-        container = sv.get_class("MassSpectrometryImagingData")
         slots = sv.class_slots("MassSpectrometryImagingData")
         for s in ["LEVEL_1_DATA", "LEVEL_2_DATA", "LEVEL_3_DATA", "LEVEL_4_DATA", "MOLECULAR_ASSIGNMENTS"]:
             assert s in slots, f"{s} missing from container"
@@ -39,6 +40,8 @@ class TestSchema:
 
 
 class TestInheritance:
+    """Level classes inherit CoreFileAttributes; the RecordSet row class does not."""
+
     @pytest.mark.parametrize("cls", LEVEL_CLASSES)
     def test_levels_inherit_core(self, sv, cls):
         assert cls in sv.all_classes()
@@ -58,6 +61,8 @@ class TestInheritance:
 
 
 class TestLevel1:
+    """Level 1 required/optional slots, multivalued analyte class, and MALDI rule."""
+
     def test_required_slots(self, sv):
         cls = "MassSpectrometryImagingLevel1"
         required = [
@@ -109,6 +114,8 @@ class TestLevel1:
 
 
 class TestEnums:
+    """Enum presence, alphabetical ordering, descriptions, and MULTI_CLASS removal."""
+
     def test_enums_present(self, sv):
         expected = [
             "MsIonizationTechniqueEnum", "MassAnalyzerTypeEnum", "MassAnalysisPolarityEnum",
@@ -140,6 +147,8 @@ class TestEnums:
 
 
 class TestMolecularAssignments:
+    """Molecular Assignments RecordSet columns, bounds, and CONFIDENCE_LEVEL-gated rules."""
+
     def test_required_columns(self, sv):
         cls = "MolecularAssignment"
         required = ["HTAN_DATA_FILE_ID", "CHANNEL_INDEX", "MZ_OBSERVED", "MOLECULAR_NAME",
@@ -176,6 +185,8 @@ class TestMolecularAssignments:
 
 
 class TestPatterns:
+    """Identifier pattern validation on RecordSet foreign keys."""
+
     def test_data_file_id_pattern_in_recordset(self, sv):
         slot = sv.induced_slot("HTAN_DATA_FILE_ID", "MolecularAssignment")
         assert slot.pattern

--- a/modules/MassSpectrometryImaging/tests/test_mass_spectrometry_imaging.py
+++ b/modules/MassSpectrometryImaging/tests/test_mass_spectrometry_imaging.py
@@ -14,6 +14,28 @@ LEVEL_CLASSES = [
     "MassSpectrometryImagingLevel4",
 ]
 
+# Required / optional slot expectations for Levels 2-4 (Level 1 is covered in TestLevel1).
+LEVEL_REQUIRED = {
+    "MassSpectrometryImagingLevel2": [
+        "SOFTWARE_AND_VERSION", "BASELINE_CORRECTION_METHOD", "PEAK_PICKING_METHOD",
+        "PEAK_PICKING_SNR_THRESHOLD", "NORMALIZATION_METHOD", "MASS_ALIGNMENT_METHOD",
+        "MASS_TOLERANCE_PPM", "MEDIAN_TIC", "TIC_CV", "MASS_ACCURACY_PPM",
+        "PIXEL_COMPLETION_RATE", "NUM_DETECTED_PEAKS", "PASSED_QC",
+    ],
+    "MassSpectrometryImagingLevel3": [
+        "NUM_ANNOTATED_CHANNELS", "NUM_UNKNOWN_CHANNELS", "SOFTWARE_AND_VERSION", "PASSED_QC",
+    ],
+    "MassSpectrometryImagingLevel4": [
+        "SEGMENTATION_METHOD", "SEGMENTATION_CLASS_COUNT", "SEGMENTATION_REFERENCE_MODALITY",
+        "PASSED_QC",
+    ],
+}
+LEVEL_OPTIONAL = {
+    "MassSpectrometryImagingLevel2": ["SMOOTHING_METHOD", "PROTOCOL_LINK", "QC_COMMENT"],
+    "MassSpectrometryImagingLevel3": ["PROTOCOL_LINK", "QC_COMMENT"],
+    "MassSpectrometryImagingLevel4": ["QC_COMMENT"],
+}
+
 
 @pytest.fixture(scope="module")
 def sv():
@@ -111,6 +133,33 @@ class TestLevel1:
                 post_slots.update(r.postconditions.slot_conditions.keys())
         assert "PREPARATION_MATRIX" in post_slots
         assert "MATRIX_DEPOSITION_METHOD" in post_slots
+
+
+class TestLevels234:
+    """Required/optional slot coverage for Levels 2-4 (mirrors TestLevel1)."""
+
+    @pytest.mark.parametrize(
+        "cls,slot", [(c, s) for c, ss in LEVEL_REQUIRED.items() for s in ss]
+    )
+    def test_required(self, sv, cls, slot):
+        assert sv.induced_slot(slot, cls).required is True, f"{slot} should be required in {cls}"
+
+    @pytest.mark.parametrize(
+        "cls,slot", [(c, s) for c, ss in LEVEL_OPTIONAL.items() for s in ss]
+    )
+    def test_optional(self, sv, cls, slot):
+        assert not sv.induced_slot(slot, cls).required, f"{slot} should be optional in {cls}"
+
+
+class TestSlotCompleteness:
+    """Every attribute on every level class carries a title and description."""
+
+    @pytest.mark.parametrize("cls", LEVEL_CLASSES + ["MolecularAssignment"])
+    def test_title_and_description(self, sv, cls):
+        klass = sv.get_class(cls)
+        for name, attr in klass.attributes.items():
+            assert attr.title, f"{cls}.{name} missing title"
+            assert attr.description, f"{cls}.{name} missing description"
 
 
 class TestEnums:

--- a/modules/MultiplexMicroscopy/src/htan_multiplexmicroscopy/datamodel/multiplex_microscopy.py
+++ b/modules/MultiplexMicroscopy/src/htan_multiplexmicroscopy/datamodel/multiplex_microscopy.py
@@ -1,5 +1,5 @@
 # Auto generated from multiplex_microscopy.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-11T19:56:07
+# Generation date: 2026-07-01T14:24:36
 # Schema: MultiplexMicroscopy
 #
 # id: https://w3id.org/htan/multiplex_microscopy

--- a/modules/MultiplexMicroscopy/src/htan_multiplexmicroscopy/datamodel/multiplex_microscopy.py
+++ b/modules/MultiplexMicroscopy/src/htan_multiplexmicroscopy/datamodel/multiplex_microscopy.py
@@ -1,5 +1,5 @@
 # Auto generated from multiplex_microscopy.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-07-01T14:24:36
+# Generation date: 2026-07-01T14:40:46
 # Schema: MultiplexMicroscopy
 #
 # id: https://w3id.org/htan/multiplex_microscopy

--- a/modules/Sequencing/src/htan_sequencing/datamodel/sequencing.py
+++ b/modules/Sequencing/src/htan_sequencing/datamodel/sequencing.py
@@ -1,5 +1,5 @@
 # Auto generated from sequencing.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-11T19:56:00
+# Generation date: 2026-07-01T14:24:30
 # Schema: Sequencing
 #
 # id: https://w3id.org/htan/sequencing

--- a/modules/Sequencing/src/htan_sequencing/datamodel/sequencing.py
+++ b/modules/Sequencing/src/htan_sequencing/datamodel/sequencing.py
@@ -1,5 +1,5 @@
 # Auto generated from sequencing.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-07-01T14:24:30
+# Generation date: 2026-07-01T14:40:39
 # Schema: Sequencing
 #
 # id: https://w3id.org/htan/sequencing

--- a/modules/SpatialOmics/src/htan_spatial/datamodel/spatial.py
+++ b/modules/SpatialOmics/src/htan_spatial/datamodel/spatial.py
@@ -1,5 +1,5 @@
 # Auto generated from spatial.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-07-01T14:24:38
+# Generation date: 2026-07-01T14:40:48
 # Schema: SpatialOmics
 #
 # id: https://w3id.org/htan/spatial

--- a/modules/SpatialOmics/src/htan_spatial/datamodel/spatial.py
+++ b/modules/SpatialOmics/src/htan_spatial/datamodel/spatial.py
@@ -1,5 +1,5 @@
 # Auto generated from spatial.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-11T19:56:09
+# Generation date: 2026-07-01T14:24:38
 # Schema: SpatialOmics
 #
 # id: https://w3id.org/htan/spatial

--- a/modules/WES/src/htan_wes/datamodel/wes.py
+++ b/modules/WES/src/htan_wes/datamodel/wes.py
@@ -1,5 +1,5 @@
 # Auto generated from wes.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-07-01T14:23:40
+# Generation date: 2026-07-01T14:39:48
 # Schema: WES
 #
 # id: https://w3id.org/htan/wes

--- a/modules/WES/src/htan_wes/datamodel/wes.py
+++ b/modules/WES/src/htan_wes/datamodel/wes.py
@@ -1,5 +1,5 @@
 # Auto generated from wes.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-11T19:55:07
+# Generation date: 2026-07-01T14:23:40
 # Schema: WES
 #
 # id: https://w3id.org/htan/wes

--- a/modules/scRNA-seq/src/htan_scrna_seq/datamodel/scrna_seq.py
+++ b/modules/scRNA-seq/src/htan_scrna_seq/datamodel/scrna_seq.py
@@ -1,5 +1,5 @@
 # Auto generated from scrna_seq.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-07-01T14:24:33
+# Generation date: 2026-07-01T14:40:43
 # Schema: scRNA-seq
 #
 # id: https://w3id.org/htan/scrna_seq

--- a/modules/scRNA-seq/src/htan_scrna_seq/datamodel/scrna_seq.py
+++ b/modules/scRNA-seq/src/htan_scrna_seq/datamodel/scrna_seq.py
@@ -1,5 +1,5 @@
 # Auto generated from scrna_seq.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-11T19:56:03
+# Generation date: 2026-07-01T14:24:33
 # Schema: scRNA-seq
 #
 # id: https://w3id.org/htan/scrna_seq


### PR DESCRIPTION
## Summary

Adds a new **MassSpectrometryImaging (MSI)** LinkML module implementing the HTAN Phase 2 Mass Spectrometry Imaging RFC (v1.3). MSI is a spatial molecular profiling modality (like spatial transcriptomics) that produces label-free, spatially resolved detection of lipids, metabolites, peptides, and proteins directly from tissue.

This PR contains **source schemas + tests + registration only**. No generated artifacts are included (see below).

## What's included

- **Domain schemas** (`modules/MassSpectrometryImaging/domains/`)
  - `level_1.yaml` – raw continuous/profile imzML acquisition annotations
  - `level_2.yaml` – processed centroided imzML processing + QC annotations
  - `level_3.yaml` – annotation-filtered OME-TIFF summary annotations
  - `level_4.yaml` – segmentation / region quantification (optional level)
  - `molecular_assignments.yaml` – Molecular Assignments RecordSet (one row per OME-TIFF channel)
  - `mass_spectrometry_imaging.yaml` – container importing all of the above
- **Module scaffolding** – `Makefile`, python package (`htan_massspectrometryimaging`), `README.md`
- **Tests** – `tests/test_mass_spectrometry_imaging.py` (24 tests)
- **Registration** – root `Makefile` (`MODULES` + `format`), `generate-python-classes.yml`, `json-schema-synapse.yml`, root `README.md`

## Design decisions

- **Inheritance**: each `MassSpectrometryImagingLevel1..4` is `is_a: CoreFileAttributes` (flat pattern, mirroring SpatialOmics — *not* the sequencing level chain and *not* `BaseImagingAttributes`).
- **RecordSet**: `MolecularAssignment` is a standalone row class (does not inherit `CoreFileAttributes`, like `ChannelMetadata`), wired into the container via `multivalued: true` + `inlined_as_list: true`.
- **Propagation**: attributes propagate downward at query time via `HTAN_PARENT_ID`, not LinkML inheritance; each level defines only its own new attributes. `PASSED_QC`, `QC_COMMENT`, `SOFTWARE_AND_VERSION`, `PROTOCOL_LINK` are re-specified per level.

## RFC v1.3 modeling decisions reflected here

- `ANALYTE_CLASS` is **multivalued**; `MULTI_CLASS` permissible value removed.
- `PREPARATION_MATRIX` / `MATRIX_DEPOSITION_METHOD` are **conditionally required only for MALDI ionization** (`MALDI` / `MALDI_2`) via a rule; not required for DESI / SIMS / IR-MALDESI / OTHER.
- `PREPARATION_INSTRUMENT_VENDOR` / `PREPARATION_INSTRUMENT_MODEL` are **optional**.
- `SPECTRUM_TYPE` is constrained to `PROFILE` at Level 1 (via rule — slot-level `equals_string` isn't allowed on enum ranges).
- Molecular-assignment columns (`MZ_THEORETICAL`, `MASS_ERROR_PPM`, `MOLECULAR_FORMULA`, `ADDUCT`, `DATABASE_SOURCE`, `DATABASE_ID`, `DATABASE_VERSION`) are gated on `CONFIDENCE_LEVEL` (1–4) via rules.
- All enum permissible values are alphabetically ordered per repo convention.

## Not in this PR (by design)

- **Generated artifacts** (`src/*/datamodel/*.py`, `JSON_Schemas/*.json`) are produced in a separate downstream `make modules-gen` PR, per repo convention.
- **Cross-row constraints** the RFC assigns to the DCC validator — channel count = RecordSet row count, `(HTAN_DATA_FILE_ID, CHANNEL_INDEX)` uniqueness, imzML continuous@L1 / centroided@L2 — are intentionally *not* in the schema (noted in the module README).
- The RFC `.docx` and the attribute workbook `.xlsx` are intentionally kept out of the repo.

## Testing

- `poetry run pytest modules/MassSpectrometryImaging/tests/` → **24 passed** (schema load, inheritance, required/optional slots, enums alphabetical + described, multivalued `ANALYTE_CLASS`, `MULTI_CLASS` removal, conditional rules, RecordSet patterns).
- `gen-python`, `gen-json-schema`, and the Synapse flat-schema script all run clean (0 errors).

> Tests are introspection-only; valid/invalid **instance** tests will follow in the downstream generated-classes PR (they require the generated dataclasses).
